### PR TITLE
Feature/coverage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run format:check
 
   test:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -49,6 +49,9 @@ jobs:
 
       - name: Run Unit Tests
         run: npm run test
+
+      - name: Run Coverage
+        run: npm run test:coverage
 
   build:
     if: github.event_name == 'push'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Run Coverage and Unit Tests
-        run: npm run test:coverage
+        run: npm run coverage
 
   build:
     if: github.event_name == 'push'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,10 +47,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Unit Tests
-        run: npm run test
-
-      - name: Run Coverage
+      - name: Run Coverage and Unit Tests
         run: npm run test:coverage
 
   build:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const config: JestConfigWithTsJest = {
   preset: "ts-jest",
   testEnvironment: "node",
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",
     "!**/node_modules/**",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,6 +10,14 @@ const config: JestConfigWithTsJest = {
     "!src/generated/**",
     "!**/main.ts",
   ],
+  // coverageThreshold: {
+  //   global: {
+  //     branches: 70,
+  //     functions: 70,
+  //     lines: 70,
+  //     statements: 70,
+  //   },
+  // },
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,13 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const config: JestConfigWithTsJest = {
   preset: "ts-jest",
   testEnvironment: "node",
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "src/**/*.{ts,tsx}",
+    "!**/node_modules/**",
+    "!src/generated/**",
+    "!**/main.ts",
+  ],
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,9 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const config: JestConfigWithTsJest = {
   preset: "ts-jest",
   testEnvironment: "node",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
   collectCoverage: false,
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint .",
     "start": "node dist/main.js",
     "test": "jest --config jest.config.ts",
-    "test:coverage": "jest --coverage --collectCoverageFrom='src/**/*.{ts,tsx}'",
+    "test:coverage": "jest --coverage",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint .",
     "start": "node dist/main.js",
     "test": "jest --config jest.config.ts",
-    "test:coverage": "jest --coverage",
+    "coverage": "jest --coverage",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "eslint .",
     "start": "node dist/main.js",
     "test": "jest --config jest.config.ts",
+    "test:coverage": "jest --coverage --collectCoverageFrom='src/**/*.{ts,tsx}'",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
## Description
Add coverage in the backend, currently is watching for all files inside ` "src/**/*.{ts,tsx}"`, ignoring `node_modules`, `generated` from prisma. 

## Main Changes

- Add the step in the pipeline, `npm run coverage` this command make the tests and coverage together.
- Add configurations in `jest.config.ts`
- Add test run on PRs
## Reviewers

@LucasMezzaJalaUniversity
@JoseCaJala
@cclaurevju
@ArielMonroy392
@MauricioLSalles
@ElamCanoJala
@AndreCarpio
@DanielRios491
@eduSpinouza
