### PR TITLE
Feature/chat integration

### DIFF
--- a/prisma/migrations/20250716194502_chats_and_messages/migration.sql
+++ b/prisma/migrations/20250716194502_chats_and_messages/migration.sql
@@ -1,0 +1,70 @@
+-- CreateEnum
+CREATE TYPE "MessageType" AS ENUM ('TEXT');
+
+-- CreateEnum
+CREATE TYPE "MessageStatus" AS ENUM ('SENT', 'DELIVERED', 'READ', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastSeen" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "type" "MessageType" NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+    "status" "MessageStatus" NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "chatId" TEXT NOT NULL,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Chat" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Chat_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_ReceivedMessages" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_ReceivedMessages_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateTable
+CREATE TABLE "_UserChats" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_UserChats_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_ReceivedMessages_B_index" ON "_ReceivedMessages"("B");
+
+-- CreateIndex
+CREATE INDEX "_UserChats_B_index" ON "_UserChats"("B");
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ReceivedMessages" ADD CONSTRAINT "_ReceivedMessages_A_fkey" FOREIGN KEY ("A") REFERENCES "Message"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ReceivedMessages" ADD CONSTRAINT "_ReceivedMessages_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_UserChats" ADD CONSTRAINT "_UserChats_A_fkey" FOREIGN KEY ("A") REFERENCES "Chat"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_UserChats" ADD CONSTRAINT "_UserChats_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250716205649_add_chat_status/migration.sql
+++ b/prisma/migrations/20250716205649_add_chat_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ChatStatus" AS ENUM ('ACTIVE', 'CLOSED');
+
+-- AlterTable
+ALTER TABLE "Chat" ADD COLUMN     "chatStatus" "ChatStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/prisma/migrations/20250716205804_change_chatstatus_name/migration.sql
+++ b/prisma/migrations/20250716205804_change_chatstatus_name/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `chatStatus` on the `Chat` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Chat" DROP COLUMN "chatStatus",
+ADD COLUMN     "status" "ChatStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/prisma/migrations/20250717025311_add_default_status_to_message/migration.sql
+++ b/prisma/migrations/20250717025311_add_default_status_to_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ALTER COLUMN "status" SET DEFAULT 'DELIVERED';

--- a/prisma/migrations/20250719021601_add_timezone_to_messages/migration.sql
+++ b/prisma/migrations/20250719021601_add_timezone_to_messages/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ALTER COLUMN "timestamp" SET DATA TYPE TIMESTAMPTZ;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,7 +171,7 @@ model Message {
   content    String
   type       MessageType
   timestamp  DateTime
-  status     MessageStatus
+  status     MessageStatus @default(DELIVERED)
   senderId   String
   chatId     String
   sender     User          @relation("SentMessages", fields: [senderId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,13 @@ model User {
   roles              UserRole[]  @default([CLIENT])
   createdAt          DateTime    @default(now())
   profilePicture     String?
-  freelancerProfile  Freelancer? @relation("UserFreelancer") 
+  freelancerProfile  Freelancer? @relation("UserFreelancer")
   clientProfile      Client?     @relation("UserClient")
+
+  lastSeen         DateTime  @default(now())
+  sentMessages     Message[] @relation("SentMessages")
+  receivedMessages Message[] @relation("ReceivedMessages")
+  chats            Chat[]    @relation("UserChats")
 }
 
 model Freelancer {
@@ -148,4 +153,37 @@ model Experience {
   endDate      DateTime   @default(now())
   freelancerId String
   freelancer   Freelancer @relation(fields: [freelancerId], references: [id], onDelete: Cascade)
+}
+
+enum MessageType {
+  TEXT
+}
+
+enum MessageStatus {
+  SENT
+  DELIVERED
+  READ
+  FAILED
+}
+
+model Message {
+  id         String        @id @default(uuid())
+  content    String
+  type       MessageType
+  timestamp  DateTime
+  status     MessageStatus
+  senderId   String
+  receiverId String
+  chatId     String
+  sender     User          @relation("SentMessages", fields: [senderId], references: [id])
+  receiver   User          @relation("ReceivedMessages", fields: [receiverId], references: [id])
+  chat       Chat          @relation(fields: [chatId], references: [id])
+}
+
+model Chat {
+  id           String    @id @default(uuid())
+  name         String    @default("")
+  createdAt    DateTime  @default(now())
+  messages     Message[]
+  participants User[]    @relation("UserChats")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,7 +170,7 @@ model Message {
   id         String        @id @default(uuid())
   content    String
   type       MessageType
-  timestamp  DateTime
+  timestamp  DateTime      @db.Timestamptz()
   status     MessageStatus @default(DELIVERED)
   senderId   String
   chatId     String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,10 +173,9 @@ model Message {
   timestamp  DateTime
   status     MessageStatus
   senderId   String
-  receiverId String
   chatId     String
   sender     User          @relation("SentMessages", fields: [senderId], references: [id])
-  receiver   User          @relation("ReceivedMessages", fields: [receiverId], references: [id])
+  receivers  User[]        @relation("ReceivedMessages")
   chat       Chat          @relation(fields: [chatId], references: [id])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -180,9 +180,15 @@ model Message {
 }
 
 model Chat {
-  id           String    @id @default(uuid())
-  name         String    @default("")
-  createdAt    DateTime  @default(now())
+  id           String     @id @default(uuid())
+  name         String     @default("")
+  createdAt    DateTime   @default(now())
   messages     Message[]
-  participants User[]    @relation("UserChats")
+  participants User[]     @relation("UserChats")
+  status   ChatStatus @default(ACTIVE)
+}
+
+enum ChatStatus {
+    ACTIVE
+    CLOSED
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import freelancersRoutes from "./contexts/CoreContext/presentation/http/routes/F
 import courseRoutes from "./contexts/LearningContext/presentation/http/routes/CourseRoutes";
 import { ErrorHandlerMiddleware } from "./contexts/Shared/infrastructure/middlewares/ErrorHandlerMiddleware";
 import userRoutes from "./contexts/CoreContext/presentation/http/routes/UserRoutes";
+import { chatRoutes } from "./contexts/CoreContext/presentation/http/routes/ChatRoutes";
 import authRoutes from "./contexts/CoreContext/presentation/http/routes/AuthRoutes";
 import swaggerUi from "swagger-ui-express";
 import { swaggerDocs } from "./config/swagger";
@@ -28,6 +29,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use("/api/health", healthRoutes);
 
 app.use("/api/users", userRoutes);
+
+app.use("/api/chats", chatRoutes);
+
 app.use("/api/freelancers", freelancersRoutes);
 
 app.use("/api/courses", courseRoutes);

--- a/src/contexts/CoreContext/application/services/ChatService.ts
+++ b/src/contexts/CoreContext/application/services/ChatService.ts
@@ -10,13 +10,15 @@ export class ChatService implements IChatService {
     @inject("CreateChatUseCase")
     private createChatUseCase: IUseCase<Chat, Chat>,
     @inject("GetChatsByUserIdUseCase")
-    private getChatsByUserIdUseCase: IUseCase<string, Chat[]>
+    private getChatsByUserIdUseCase: IUseCase<string, Chat[]>,
+    @inject("GetChatByIdUseCase")
+    private getChatByIdUseCase: IUseCase<string, Chat>
   ) {}
   async getManyByUserId(userId: string): Promise<Chat[]> {
     return await this.getChatsByUserIdUseCase.execute(userId);
   }
-  get(id: string): Promise<Chat | null> {
-    throw new Error("Method not implemented.");
+  async get(id: string): Promise<Chat> {
+    return await this.getChatByIdUseCase.execute(id);
   }
   getAll(): Promise<Chat[]> {
     throw new Error("Method not implemented.");

--- a/src/contexts/CoreContext/application/services/ChatService.ts
+++ b/src/contexts/CoreContext/application/services/ChatService.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { inject, injectable } from "tsyringe";
+import { IChatService } from "../../domain/interfaces/services/IChatService";
+import { Chat } from "../../domain/aggregates/Chat";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+
+@injectable()
+export class ChatService implements IChatService {
+  constructor(
+    @inject("CreateChatUseCase")
+    private createChatUseCase: IUseCase<Chat, Chat>,
+    @inject("GetChatsByUserIdUseCase")
+    private getChatsByUserIdUseCase: IUseCase<string, Chat[]>
+  ) {}
+  async getManyByUserId(userId: string): Promise<Chat[]> {
+    return await this.getChatsByUserIdUseCase.execute(userId);
+  }
+  get(id: string): Promise<Chat | null> {
+    throw new Error("Method not implemented.");
+  }
+  getAll(): Promise<Chat[]> {
+    throw new Error("Method not implemented.");
+  }
+  update(id: string, object: Chat): Promise<Chat> {
+    throw new Error("Method not implemented.");
+  }
+  async create(chat: Chat): Promise<Chat> {
+    return await this.createChatUseCase.execute(chat);
+  }
+  delete(id: string): Promise<string | void> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/contexts/CoreContext/application/services/MessageService.ts
+++ b/src/contexts/CoreContext/application/services/MessageService.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { inject, injectable } from "tsyringe";
+import { IMessageService } from "../../domain/interfaces/services/IMessageService";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { Message } from "../../domain/entities/Message";
+
+@injectable()
+export class MessageService implements IMessageService {
+  constructor(
+    @inject("CreateMessageUseCase")
+    private createMessageUseCase: IUseCase<Message, Message>,
+    @inject("GetMessagesByChatIdUseCase")
+    private getMessagesByChatIdUseCase: IUseCase<string, Message[]>,
+    @inject("UpdateMessageStatusUseCase")
+    private UpdateMessageStatusUseCase: IUseCase<
+      { chatId: string; userId: string },
+      void
+    >
+  ) {}
+  async getManyByChatId(chatId: string): Promise<Message[]> {
+    return await this.getMessagesByChatIdUseCase.execute(chatId);
+  }
+  async markManyAsRead(chatId: string, userId: string): Promise<void> {
+    return await this.UpdateMessageStatusUseCase.execute({ chatId, userId });
+  }
+  get(id: string): Promise<Message | null> {
+    throw new Error("Method not implemented.");
+  }
+  getAll(): Promise<Message[]> {
+    throw new Error("Method not implemented.");
+  }
+  update(id: string, object: Message): Promise<Message> {
+    throw new Error("Method not implemented.");
+  }
+  async create(message: Message): Promise<Message> {
+    return await this.createMessageUseCase.execute(message);
+  }
+  delete(id: string): Promise<string | void> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/CreateChatUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/CreateChatUseCase.ts
@@ -1,0 +1,25 @@
+import { IChatRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IChatRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+import { Chat } from "@/contexts/CoreContext/domain/aggregates/Chat";
+
+@injectable()
+export class CreateChatUsecase implements IUseCase<Chat, Chat> {
+  constructor(
+    @inject("IChatRepository")
+    private chatRepository: IChatRepository
+  ) {}
+
+  async execute(chat: Chat): Promise<Chat> {
+    const createdChat = await this.chatRepository.create(chat);
+    if (!createdChat) {
+      throw new ApiError(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        "Failed to create chat"
+      );
+    }
+    return createdChat;
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/CreateMessageUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/CreateMessageUseCase.ts
@@ -1,0 +1,16 @@
+import { Message } from "@/contexts/CoreContext/domain/entities/Message";
+import { IMessageRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IMessageRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class CreateMessageUseCase implements IUseCase<Message, Message> {
+  constructor(
+    @inject("IMessageRepository")
+    private messageRepository: IMessageRepository
+  ) {}
+
+  async execute(message: Message): Promise<Message> {
+    return this.messageRepository.create(message);
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/GetChatByIdUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/GetChatByIdUseCase.ts
@@ -1,0 +1,19 @@
+import { Chat } from "@/contexts/CoreContext/domain/aggregates/Chat";
+import { IChatRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IChatRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class GetChatByIdUseCase implements IUseCase<string, Chat> {
+  constructor(
+    @inject("IChatRepository")
+    private chatRepository: IChatRepository
+  ) {}
+  async execute(id: string): Promise<Chat> {
+    const chat = await this.chatRepository.getById(id);
+    if (!chat) throw new ApiError(StatusCodes.NOT_FOUND, "Chat not found");
+    return chat;
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/GetChatsByUserIdUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/GetChatsByUserIdUseCase.ts
@@ -1,0 +1,15 @@
+import { Chat } from "@/contexts/CoreContext/domain/aggregates/Chat";
+import { IChatRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IChatRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class GetChatsByUserIdUseCase implements IUseCase<string, Chat[]> {
+  constructor(
+    @inject("IChatRepository")
+    private chatRepository: IChatRepository
+  ) {}
+  async execute(userId: string): Promise<Chat[]> {
+    return await this.chatRepository.findManyByUserId(userId);
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/GetMessagesByChatIdUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/GetMessagesByChatIdUseCase.ts
@@ -1,0 +1,15 @@
+import { Message } from "@/contexts/CoreContext/domain/entities/Message";
+import { IMessageRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IMessageRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class GetMessagesByChatIdUseCase implements IUseCase<string, Message[]> {
+  constructor(
+    @inject("IMessageRepository")
+    private messageRepository: IMessageRepository
+  ) {}
+  async execute(id: string): Promise<Message[]> {
+    return await this.messageRepository.findManyByChatId(id);
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/chats/UpdateMessageStatusUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/chats/UpdateMessageStatusUseCase.ts
@@ -1,0 +1,19 @@
+import { IMessageRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IMessageRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class UpdateMessageStatusUseCase
+  implements IUseCase<{ chatId: string; userId: string }, void>
+{
+  constructor(
+    @inject("IMessageRepository")
+    private messageRepository: IMessageRepository
+  ) {}
+  async execute(params: { chatId: string; userId: string }): Promise<void> {
+    await this.messageRepository.markChatMessagesAsRead(
+      params.chatId,
+      params.userId
+    );
+  }
+}

--- a/src/contexts/CoreContext/domain/aggregates/Chat.ts
+++ b/src/contexts/CoreContext/domain/aggregates/Chat.ts
@@ -41,10 +41,13 @@ export class Chat extends AggregateRoot<ChatProps> {
   }
 
   public static create(props: ChatProps, id?: UniqueEntityID): Chat {
-    if (props.participantsIds.length == 0) {
+    const participantsIds = [
+      ...new Set(props.participantsIds.map((id) => id.toString())),
+    ];
+    if (participantsIds.length < 2) {
       throw new ApiError(
         StatusCodes.BAD_REQUEST,
-        "Chat must have participants"
+        "Chat must have at least 2 participants"
       );
     }
     return new Chat(

--- a/src/contexts/CoreContext/domain/aggregates/Chat.ts
+++ b/src/contexts/CoreContext/domain/aggregates/Chat.ts
@@ -1,0 +1,72 @@
+import { AggregateRoot } from "@/contexts/Shared/domain/AgregateRoot";
+import { ChatName } from "../valueObjects/ChatName";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import { Message } from "../entities/Message";
+
+export type ChatStatus = "ACTIVE" | "CLOSED";
+
+export interface ChatProps {
+  name?: ChatName;
+  createdAt?: Date;
+  messages: Message[];
+  participantsIds: UniqueEntityID[];
+  status?: ChatStatus;
+}
+
+export class Chat extends AggregateRoot<ChatProps> {
+  constructor(props: ChatProps, id?: UniqueEntityID) {
+    super(props, id);
+  }
+
+  get chatName() {
+    return this.props.name;
+  }
+
+  get createdAt() {
+    return this.props.createdAt;
+  }
+
+  get messages() {
+    return this.props.messages;
+  }
+
+  get participantsIds() {
+    return this.props.participantsIds;
+  }
+
+  get status() {
+    return this.props.status;
+  }
+
+  public static create(props: ChatProps, id?: UniqueEntityID): Chat {
+    if (props.participantsIds.length == 0) {
+      throw new ApiError(
+        StatusCodes.BAD_REQUEST,
+        "Chat must have participants"
+      );
+    }
+    return new Chat(
+      {
+        name: props.name ?? ChatName.create(""),
+        createdAt: props.createdAt ?? new Date(),
+        messages: props.messages ?? [],
+        participantsIds: props.participantsIds,
+      },
+      id
+    );
+  }
+
+  public setChatName(name: string): void {
+    this.props.name = ChatName.create(name);
+  }
+
+  public addMessage(message: Message): void {
+    this.props.messages.push(message);
+  }
+
+  public addParticipant(participantId: UniqueEntityID): void {
+    this.props.participantsIds.push(participantId);
+  }
+}

--- a/src/contexts/CoreContext/domain/aggregates/User.ts
+++ b/src/contexts/CoreContext/domain/aggregates/User.ts
@@ -16,6 +16,7 @@ export interface UserProps {
   freelancerId?: UniqueEntityID;
   createdAt: Date;
   profilePicture?: string;
+  lastSeen?: Date;
 }
 
 export class User extends AggregateRoot<UserProps> {
@@ -50,6 +51,10 @@ export class User extends AggregateRoot<UserProps> {
 
   get isFreelancer(): boolean {
     return this.roles.includes("FREELANCER");
+  }
+
+  get lastSeen(): Date {
+    return this.props.lastSeen ?? new Date();
   }
 
   // Methods to manage roles
@@ -114,6 +119,7 @@ export class User extends AggregateRoot<UserProps> {
         freelancerId: profiles.freelancerProfile,
         createdAt: props.createdAt ?? new Date(),
         profilePicture: props.profilePicture ?? "",
+        lastSeen: props.lastSeen ?? new Date(),
       },
       id
     );

--- a/src/contexts/CoreContext/domain/entities/Message.ts
+++ b/src/contexts/CoreContext/domain/entities/Message.ts
@@ -1,0 +1,79 @@
+import { Entity } from "@/contexts/Shared/domain/Entity";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+
+export type MessageType = "TEXT";
+
+export type MessageStatus = "SENT" | "DELIVERED" | "READ" | "FAILED";
+
+export interface MessageProps {
+  content: string;
+  type: MessageType;
+  timestamp: Date;
+  status?: MessageStatus;
+  senderId: UniqueEntityID;
+  chatId: UniqueEntityID;
+}
+
+export class Message extends Entity<MessageProps> {
+  constructor(props: MessageProps, id: UniqueEntityID) {
+    super(props, id);
+  }
+
+  public static create(props: MessageProps, id: UniqueEntityID): Message {
+    if (!props.content) {
+      throw new ApiError(
+        StatusCodes.BAD_REQUEST,
+        "Message must have a content"
+      );
+    }
+    if (!props.senderId) {
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Sender not defined");
+    }
+    if (!props.chatId) {
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Chat not defined");
+    }
+    return new Message(
+      {
+        ...props,
+        status: "SENT",
+        timestamp: props.timestamp ?? new Date(),
+      },
+      id
+    );
+  }
+  get id(): UniqueEntityID {
+    return this._id;
+  }
+  get content(): string {
+    return this.content;
+  }
+  get type(): MessageType {
+    return this.type;
+  }
+  get timestamp(): Date {
+    return this.timestamp;
+  }
+  get status(): MessageStatus {
+    return this.status;
+  }
+  get senderId(): UniqueEntityID {
+    return this.senderId;
+  }
+  get chatId(): UniqueEntityID {
+    return this.chatId;
+  }
+  public updateContent(content: string): void {
+    this.props.content = content;
+  }
+  public updateType(type: MessageType): void {
+    this.props.type = type;
+  }
+  public updateStatus(status: MessageStatus): void {
+    this.props.status = status;
+  }
+  public toString(): string {
+    return `[${this.timestamp} | ${this.type} | ${this.status}] ${this.senderId} > ${this.chatId}: ${this.content}`;
+  }
+}

--- a/src/contexts/CoreContext/domain/entities/Message.ts
+++ b/src/contexts/CoreContext/domain/entities/Message.ts
@@ -1,6 +1,8 @@
 import { Entity } from "@/contexts/Shared/domain/Entity";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { MessageStatus as MessageStatusPrisma } from "@/generated/prisma";
+import { MessageType as MessageTypePrisma } from "@/generated/prisma";
 import { StatusCodes } from "http-status-codes";
 
 export type MessageType = "TEXT";
@@ -11,9 +13,10 @@ export interface MessageProps {
   content: string;
   type: MessageType;
   timestamp: Date;
-  status?: MessageStatus;
+  status: MessageStatus;
   senderId: UniqueEntityID;
   chatId: UniqueEntityID;
+  receiversIds: UniqueEntityID[];
 }
 
 export class Message extends Entity<MessageProps> {
@@ -23,10 +26,7 @@ export class Message extends Entity<MessageProps> {
 
   public static create(props: MessageProps, id: UniqueEntityID): Message {
     if (!props.content) {
-      throw new ApiError(
-        StatusCodes.BAD_REQUEST,
-        "Message must have a content"
-      );
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Message must have content");
     }
     if (!props.senderId) {
       throw new ApiError(StatusCodes.BAD_REQUEST, "Sender not defined");
@@ -34,10 +34,24 @@ export class Message extends Entity<MessageProps> {
     if (!props.chatId) {
       throw new ApiError(StatusCodes.BAD_REQUEST, "Chat not defined");
     }
+    if (props.status) {
+      const statusIsValid = Object.values(MessageStatusPrisma).includes(
+        props.status as MessageStatusPrisma
+      );
+      if (!statusIsValid)
+        throw new ApiError(StatusCodes.BAD_REQUEST, "Unknown message status");
+    }
+    if (!props.type)
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Type is not defined");
+    const typeIsValid = Object.values(MessageTypePrisma).includes(
+      props.type as MessageTypePrisma
+    );
+    if (!typeIsValid)
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Unknown message type");
     return new Message(
       {
         ...props,
-        status: "SENT",
+        status: props.status ?? "SENT",
         timestamp: props.timestamp ?? new Date(),
       },
       id
@@ -47,22 +61,25 @@ export class Message extends Entity<MessageProps> {
     return this._id;
   }
   get content(): string {
-    return this.content;
+    return this.props.content;
   }
   get type(): MessageType {
-    return this.type;
+    return this.props.type;
   }
   get timestamp(): Date {
-    return this.timestamp;
+    return this.props.timestamp;
   }
   get status(): MessageStatus {
-    return this.status;
+    return this.props.status;
   }
   get senderId(): UniqueEntityID {
-    return this.senderId;
+    return this.props.senderId;
   }
   get chatId(): UniqueEntityID {
-    return this.chatId;
+    return this.props.chatId;
+  }
+  get receiversIds(): UniqueEntityID[] {
+    return this.props.receiversIds;
   }
   public updateContent(content: string): void {
     this.props.content = content;

--- a/src/contexts/CoreContext/domain/interfaces/controllers/IChatController.ts
+++ b/src/contexts/CoreContext/domain/interfaces/controllers/IChatController.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+
+export interface IChatController {
+  create(req: Request, res: Response): Promise<void>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/controllers/IMessageController.ts
+++ b/src/contexts/CoreContext/domain/interfaces/controllers/IMessageController.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+
+export interface IMessageController {
+  create(req: Request, res: Response): Promise<void>;
+  getMessagesByChatId(req: Request, res: Response): Promise<void>;
+  updateMessageStatus(req: Request, res: Response): Promise<void>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/controllers/IUserController.ts
+++ b/src/contexts/CoreContext/domain/interfaces/controllers/IUserController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 
 export interface IUserController {
   get(req: Request, res: Response): void;
+  getChats(req: Request, res: Response): Promise<void>;
   post(req: Request, res: Response): void;
   freelance(req: Request, res: Response): void;
   updateUser(req: Request, res: Response): Promise<void>;

--- a/src/contexts/CoreContext/domain/interfaces/dao/ChatDao.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dao/ChatDao.ts
@@ -1,0 +1,9 @@
+import {
+  Chat as ChatPrisma,
+  Message as MessagePrisma,
+} from "@/generated/prisma";
+
+export interface ChatDao extends ChatPrisma {
+  messages: MessagePrisma[];
+  participantsIds: string[];
+}

--- a/src/contexts/CoreContext/domain/interfaces/dao/MessageDao.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dao/MessageDao.ts
@@ -1,0 +1,5 @@
+import { Message } from "@/generated/prisma";
+
+export interface MessageDao extends Message {
+  receiversIds: string[];
+}

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IChatDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IChatDto.ts
@@ -1,0 +1,11 @@
+import { ChatStatus } from "../../aggregates/Chat";
+import { MessageDto } from "./IMessageDto";
+
+export interface ChatDto {
+  id?: string;
+  name?: string;
+  messages: MessageDto[];
+  participansIds: string[];
+  createdAt?: Date;
+  status: ChatStatus;
+}

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IChatDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IChatDto.ts
@@ -5,7 +5,7 @@ export interface ChatDto {
   id?: string;
   name?: string;
   messages: MessageDto[];
-  participansIds: string[];
+  participantsIds: string[];
   createdAt?: Date;
   status: ChatStatus;
 }

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IMessageDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IMessageDto.ts
@@ -1,0 +1,12 @@
+import { MessageStatus, MessageType } from "../../entities/Message";
+
+export interface MessageDto {
+  id?: string;
+  content: string;
+  type: MessageType;
+  timestamp: Date;
+  senderId: string;
+  receiversIds?: string[];
+  status: MessageStatus;
+  chatId: string;
+}

--- a/src/contexts/CoreContext/domain/interfaces/repositories/IChatRepository.ts
+++ b/src/contexts/CoreContext/domain/interfaces/repositories/IChatRepository.ts
@@ -1,0 +1,6 @@
+import { IRepository } from "@/contexts/Shared/domain/repository/IRepository";
+import { Chat } from "../../aggregates/Chat";
+
+export interface IChatRepository extends IRepository<Chat> {
+  findManyByUserId(userId: string): Promise<Chat[]>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/repositories/IMessageRepository.ts
+++ b/src/contexts/CoreContext/domain/interfaces/repositories/IMessageRepository.ts
@@ -1,0 +1,7 @@
+import { IRepository } from "@/contexts/Shared/domain/repository/IRepository";
+import { Message } from "../../entities/Message";
+
+export interface IMessageRepository extends IRepository<Message> {
+  findManyByChatId(chatId: string): Promise<Message[]>;
+  markChatMessagesAsRead(chatId: string, userId: string): Promise<void>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/services/IChatService.ts
+++ b/src/contexts/CoreContext/domain/interfaces/services/IChatService.ts
@@ -1,0 +1,6 @@
+import { IService } from "@/contexts/Shared/domain/service/IService";
+import { Chat } from "../../aggregates/Chat";
+
+export interface IChatService extends IService<Chat> {
+  getManyByUserId(userId: string): Promise<Chat[]>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/services/IMessageService.ts
+++ b/src/contexts/CoreContext/domain/interfaces/services/IMessageService.ts
@@ -1,0 +1,7 @@
+import { IService } from "@/contexts/Shared/domain/service/IService";
+import { Message } from "../../entities/Message";
+
+export interface IMessageService extends IService<Message> {
+  getManyByChatId(chatId: string): Promise<Message[]>;
+  markManyAsRead(chatId: string, userId: string): Promise<void>;
+}

--- a/src/contexts/CoreContext/domain/valueObjects/ChatName.ts
+++ b/src/contexts/CoreContext/domain/valueObjects/ChatName.ts
@@ -1,0 +1,30 @@
+import { ValueObject } from "@/contexts/Shared/domain/ValueObject";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+
+interface ChatNameProps {
+  value: string;
+}
+
+export class ChatName extends ValueObject<ChatNameProps> {
+  public static maxLength: number = 50;
+
+  get value(): string {
+    return this.props.value;
+  }
+
+  private constructor(props: ChatNameProps) {
+    super(props);
+  }
+
+  public static create(value: string): ChatName {
+    if (value.length > this.maxLength) {
+      throw new ApiError(
+        StatusCodes.BAD_REQUEST,
+        `Chat name must be less than ${this.maxLength} characters`
+      );
+    }
+
+    return new ChatName({ value });
+  }
+}

--- a/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { injectable } from "tsyringe";
+import { IChatRepository } from "../../domain/interfaces/repositories/IChatRepository";
+import { Chat } from "../../domain/aggregates/Chat";
+import PrismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { ChatMapper } from "../../mappers/ChatMapper";
+import { ChatDao } from "../../domain/interfaces/dao/ChatDao";
+
+@injectable()
+export class ChatRepository implements IChatRepository {
+  async findManyByUserId(userId: string): Promise<Chat[]> {
+    try {
+      const userPrisma = await PrismaClient.user.findFirst({
+        where: { id: userId },
+        include: {
+          chats: {
+            include: {
+              participants: {
+                select: {
+                  id: true,
+                },
+              },
+              messages: { orderBy: { timestamp: "asc" } },
+            },
+          },
+        },
+      });
+      const chatsDao: ChatDao[] =
+        userPrisma?.chats?.map((chat) => {
+          return {
+            ...chat,
+            participantsIds: chat.participants.map((p) => p.id),
+          };
+        }) ?? [];
+      const chatsDomain = ChatMapper.ManyPersistenceToDomain(chatsDao);
+      return chatsDomain;
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  getAll(): Promise<Chat[]> {
+    throw new Error("Method not implemented.");
+  }
+  getById(id: string): Promise<Chat | null> {
+    throw new Error("Method not implemented.");
+  }
+  delete(id: string): Promise<string | void> {
+    throw new Error("Method not implemented.");
+  }
+  async create(object: Chat): Promise<Chat> {
+    try {
+      const chatPrisma = ChatMapper.DomainToPersistence(object);
+      const newChat = await PrismaClient.chat.create({
+        data: {
+          name: chatPrisma.name,
+          participants: {
+            connect: chatPrisma.participantsIds.map((id) => ({ id })),
+          },
+        },
+        include: { participants: { select: { id: true } }, messages: true },
+      });
+      const newChatDao: ChatDao = {
+        ...newChat,
+        messages: newChat.messages,
+        participantsIds: newChat.participants.map((p) => p.id),
+      };
+      const newChatDomain = ChatMapper.PersistenceToDomain(newChatDao);
+      return newChatDomain;
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  update(id: string, object: Chat): Promise<void | Chat> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
@@ -23,7 +23,7 @@ export class ChatRepository implements IChatRepository {
                   id: true,
                 },
               },
-              messages: { orderBy: { timestamp: "asc" } },
+              messages: { orderBy: { timestamp: "desc" }, take: 1 },
             },
           },
         },

--- a/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ChatRepository.ts
@@ -6,12 +6,14 @@ import PrismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import { ChatMapper } from "../../mappers/ChatMapper";
 import { ChatDao } from "../../domain/interfaces/dao/ChatDao";
+import { StatusCodes } from "http-status-codes";
+import { PrismaClientKnownRequestError } from "@/generated/prisma/runtime/library";
 
 @injectable()
 export class ChatRepository implements IChatRepository {
   async findManyByUserId(userId: string): Promise<Chat[]> {
     try {
-      const userPrisma = await PrismaClient.user.findFirst({
+      const userPrisma = await PrismaClient.user.findFirstOrThrow({
         where: { id: userId },
         include: {
           chats: {
@@ -36,19 +38,58 @@ export class ChatRepository implements IChatRepository {
       const chatsDomain = ChatMapper.ManyPersistenceToDomain(chatsDao);
       return chatsDomain;
     } catch (error) {
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new ApiError(StatusCodes.NOT_FOUND, "User not found");
+      } else {
+        throw new ApiError();
+      }
+    }
+  }
+
+  getAll(): Promise<Chat[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getById(id: string): Promise<Chat | null> {
+    try {
+      const chatPrisma = await PrismaClient.chat.findFirst({
+        where: { id },
+
+        include: {
+          messages: {
+            orderBy: { timestamp: "asc" },
+            include: { receivers: { select: { id: true } } },
+          },
+          participants: { select: { id: true } },
+        },
+      });
+      if (chatPrisma) {
+        const chatPrismaMapped: ChatDao = {
+          ...chatPrisma,
+          participantsIds: chatPrisma?.participants.map((p) => p.id),
+          messages: chatPrisma.messages.map((message) => {
+            return {
+              ...message,
+              receiversIds: message.receivers.map((r) => r.id),
+            };
+          }),
+        };
+        const chatDomain = ChatMapper.PersistenceToDomain(chatPrismaMapped);
+        return chatDomain;
+      } else return null;
+    } catch (error) {
       console.log(error);
       throw new ApiError();
     }
   }
-  getAll(): Promise<Chat[]> {
-    throw new Error("Method not implemented.");
-  }
-  getById(id: string): Promise<Chat | null> {
-    throw new Error("Method not implemented.");
-  }
+
   delete(id: string): Promise<string | void> {
     throw new Error("Method not implemented.");
   }
+
   async create(object: Chat): Promise<Chat> {
     try {
       const chatPrisma = ChatMapper.DomainToPersistence(object);
@@ -69,10 +110,17 @@ export class ChatRepository implements IChatRepository {
       const newChatDomain = ChatMapper.PersistenceToDomain(newChatDao);
       return newChatDomain;
     } catch (error) {
-      console.log(error);
-      throw new ApiError();
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new ApiError(StatusCodes.NOT_FOUND, "User not found");
+      } else {
+        throw new ApiError();
+      }
     }
   }
+
   update(id: string, object: Chat): Promise<void | Chat> {
     throw new Error("Method not implemented.");
   }

--- a/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
@@ -66,7 +66,7 @@ export class MessageRepository implements IMessageRepository {
       const newMessagePrisma = await PrismaClient.message.create({
         data: {
           content: messagePrisma.content,
-          timestamp: messagePrisma.timestamp,
+          timestamp: messagePrisma.timestamp.toISOString(),
           type: messagePrisma.type,
           chat: {
             connect: { id: messagePrisma.chatId },

--- a/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { injectable } from "tsyringe";
+import { IMessageRepository } from "../../domain/interfaces/repositories/IMessageRepository";
+import { Message } from "../../domain/entities/Message";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import PrismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient";
+import { MessageMapper } from "../../mappers/MessageMapper";
+
+@injectable()
+export class MessageRepository implements IMessageRepository {
+  async markChatMessagesAsRead(chatId: string, userId: string): Promise<void> {
+    try {
+      await PrismaClient.message.updateMany({
+        where: {
+          chatId: chatId,
+          NOT: {
+            senderId: userId,
+          },
+        },
+        data: {
+          status: "READ",
+        },
+      });
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  async findManyByChatId(chatId: string): Promise<Message[]> {
+    try {
+      const messagesPrisma = await PrismaClient.message.findMany({
+        where: { chatId: chatId },
+      });
+      const messagesDomain =
+        MessageMapper.ManyPersistenceToDomain(messagesPrisma);
+      return messagesDomain;
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  getAll(): Promise<Message[]> {
+    throw new Error("Method not implemented.");
+  }
+  async getById(id: string): Promise<Message | null> {
+    try {
+      const messagePrisma = await PrismaClient.message.findFirst({
+        where: { id: id },
+      });
+      if (!messagePrisma) {
+        return null;
+      }
+      const messageDomain = MessageMapper.PersistenceToDomain(messagePrisma);
+      return messageDomain;
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  delete(id: string): Promise<string | void> {
+    throw new Error("Method not implemented.");
+  }
+  async create(object: Message): Promise<Message> {
+    try {
+      const messagePrisma = MessageMapper.DomainToPersistence(object);
+      const newMessagePrisma = await PrismaClient.message.create({
+        data: {
+          content: messagePrisma.content,
+          timestamp: messagePrisma.timestamp,
+          type: messagePrisma.type,
+          chat: {
+            connect: { id: messagePrisma.chatId },
+          },
+          sender: {
+            connect: { id: messagePrisma.senderId },
+          },
+        },
+      });
+      const newMessageDomain =
+        MessageMapper.PersistenceToDomain(newMessagePrisma);
+      return newMessageDomain;
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  }
+  async update(id: string, object: Message): Promise<void | Message> {
+    try {
+      const messagePrisma = MessageMapper.DomainToPersistence(object);
+      const updatedMessagePrisma = await PrismaClient.message.update({
+        where: { id: id },
+        data: {
+          content: messagePrisma.content,
+          type: messagePrisma.type,
+          status: messagePrisma.status,
+        },
+      });
+      const updatedMessageDomain =
+        MessageMapper.PersistenceToDomain(updatedMessagePrisma);
+      return updatedMessageDomain;
+    } catch (error) {
+      console.log(error);
+
+      throw new ApiError();
+    }
+  }
+}

--- a/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/MessageRepository.ts
@@ -5,11 +5,22 @@ import { Message } from "../../domain/entities/Message";
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import PrismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient";
 import { MessageMapper } from "../../mappers/MessageMapper";
+import { PrismaClientKnownRequestError } from "@/generated/prisma/runtime/library";
+import { StatusCodes } from "http-status-codes";
+import { MessageDao } from "../../domain/interfaces/dao/MessageDao";
 
 @injectable()
 export class MessageRepository implements IMessageRepository {
   async markChatMessagesAsRead(chatId: string, userId: string): Promise<void> {
     try {
+      await PrismaClient.chat.findUniqueOrThrow({
+        where: { id: chatId },
+        select: { id: true },
+      });
+      await PrismaClient.user.findUniqueOrThrow({
+        where: { id: userId },
+        select: { id: true },
+      });
       await PrismaClient.message.updateMany({
         where: {
           chatId: chatId,
@@ -23,67 +34,139 @@ export class MessageRepository implements IMessageRepository {
       });
     } catch (error) {
       console.log(error);
-      throw new ApiError();
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new ApiError(
+          StatusCodes.NOT_FOUND,
+          `${error.meta?.modelName ?? "Resource"} not found`
+        );
+      } else {
+        throw new ApiError();
+      }
     }
   }
+
   async findManyByChatId(chatId: string): Promise<Message[]> {
     try {
+      await PrismaClient.chat.findUniqueOrThrow({
+        where: { id: chatId },
+        select: { id: true },
+      });
       const messagesPrisma = await PrismaClient.message.findMany({
         where: { chatId: chatId },
+        include: { receivers: { select: { id: true } } },
       });
-      const messagesDomain =
-        MessageMapper.ManyPersistenceToDomain(messagesPrisma);
+      const messagesDao = messagesPrisma.map((message) => {
+        return { ...message, receiversIds: message.receivers.map((r) => r.id) };
+      });
+      const messagesDomain = MessageMapper.ManyPersistenceToDomain(messagesDao);
       return messagesDomain;
     } catch (error) {
       console.log(error);
-      throw new ApiError();
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new ApiError(
+          StatusCodes.NOT_FOUND,
+          `${error.meta?.modelName ?? "Resource"} not found`
+        );
+      } else {
+        throw new ApiError();
+      }
     }
   }
+
   getAll(): Promise<Message[]> {
     throw new Error("Method not implemented.");
   }
+
   async getById(id: string): Promise<Message | null> {
     try {
       const messagePrisma = await PrismaClient.message.findFirst({
         where: { id: id },
+        include: { receivers: { select: { id: true } } },
       });
       if (!messagePrisma) {
         return null;
       }
-      const messageDomain = MessageMapper.PersistenceToDomain(messagePrisma);
+      const messageDao = {
+        ...messagePrisma,
+        receiversIds: messagePrisma.receivers.map((r) => r.id),
+      };
+      const messageDomain = MessageMapper.PersistenceToDomain(messageDao);
       return messageDomain;
     } catch (error) {
       console.log(error);
       throw new ApiError();
     }
   }
+
   delete(id: string): Promise<string | void> {
     throw new Error("Method not implemented.");
   }
+
   async create(object: Message): Promise<Message> {
     try {
-      const messagePrisma = MessageMapper.DomainToPersistence(object);
+      const messageDao: MessageDao = MessageMapper.DomainToPersistence(object);
+      const chat = await PrismaClient.chat.findFirstOrThrow({
+        where: { id: messageDao.chatId },
+        include: { participants: { select: { id: true } } },
+      });
+      const receiversIds = chat.participants
+        .map((p) => p.id)
+        .filter((id) => id != messageDao.senderId);
       const newMessagePrisma = await PrismaClient.message.create({
         data: {
-          content: messagePrisma.content,
-          timestamp: messagePrisma.timestamp.toISOString(),
-          type: messagePrisma.type,
+          id: messageDao.id,
+          content: messageDao.content,
+          timestamp: messageDao.timestamp.toISOString(),
+          type: messageDao.type,
           chat: {
-            connect: { id: messagePrisma.chatId },
+            connect: { id: messageDao.chatId },
           },
           sender: {
-            connect: { id: messagePrisma.senderId },
+            connect: { id: messageDao.senderId },
           },
+          receivers: { connect: receiversIds.map((id) => ({ id })) },
+        },
+        include: {
+          receivers: { select: { id: true } },
         },
       });
-      const newMessageDomain =
-        MessageMapper.PersistenceToDomain(newMessagePrisma);
+      const newMessageDao = {
+        ...newMessagePrisma,
+        receiversIds: newMessagePrisma.receivers.map((r) => r.id),
+      };
+      const newMessageDomain = MessageMapper.PersistenceToDomain(newMessageDao);
       return newMessageDomain;
     } catch (error) {
       console.log(error);
-      throw new ApiError();
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new ApiError(
+          StatusCodes.BAD_REQUEST,
+          "Error saving the message, duplicated ids"
+        );
+      }
+      if (
+        error instanceof PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new ApiError(
+          StatusCodes.NOT_FOUND,
+          `${error.meta?.modelName ?? "Resource"} not found`
+        );
+      } else {
+        throw new ApiError();
+      }
     }
   }
+
   async update(id: string, object: Message): Promise<void | Message> {
     try {
       const messagePrisma = MessageMapper.DomainToPersistence(object);
@@ -94,9 +177,14 @@ export class MessageRepository implements IMessageRepository {
           type: messagePrisma.type,
           status: messagePrisma.status,
         },
+        include: { receivers: { select: { id: true } } },
       });
+      const messageDao = {
+        ...messagePrisma,
+        receiversIds: updatedMessagePrisma.receivers.map((r) => r.id),
+      };
       const updatedMessageDomain =
-        MessageMapper.PersistenceToDomain(updatedMessagePrisma);
+        MessageMapper.PersistenceToDomain(messageDao);
       return updatedMessageDomain;
     } catch (error) {
       console.log(error);

--- a/src/contexts/CoreContext/mappers/ChatMapper.ts
+++ b/src/contexts/CoreContext/mappers/ChatMapper.ts
@@ -32,12 +32,14 @@ export class ChatMapper {
     };
   }
 
-  public static DomainToPersistence(chatDomain: Chat): ChatPrisma {
+  public static DomainToPersistence(chatDomain: Chat): ChatDao {
     return {
       id: chatDomain.id.toString(),
       createdAt: chatDomain.createdAt ?? new Date(),
       name: chatDomain.chatName?.value ?? "",
       status: chatDomain.status ?? "ACTIVE",
+      participantsIds: chatDomain.participantsIds.map((id) => id.toString()),
+      messages: MessageMapper.ManyDomainToPersistence(chatDomain.messages),
     };
   }
 

--- a/src/contexts/CoreContext/mappers/ChatMapper.ts
+++ b/src/contexts/CoreContext/mappers/ChatMapper.ts
@@ -11,7 +11,7 @@ export class ChatMapper {
     return Chat.create(
       {
         messages: MessageMapper.ManyDtoToDomain(chatDto.messages),
-        participantsIds: chatDto.participansIds.map(
+        participantsIds: chatDto.participantsIds.map(
           (id) => new UniqueEntityID(id)
         ),
         createdAt: chatDto.createdAt,
@@ -26,7 +26,7 @@ export class ChatMapper {
       id: chatDomain.id.toString(),
       name: chatDomain.chatName?.value,
       messages: MessageMapper.ManyDomainToDto(chatDomain.messages),
-      participansIds: chatDomain.participantsIds.map((id) => id.toString()),
+      participantsIds: chatDomain.participantsIds.map((id) => id.toString()),
       status: chatDomain.status ?? "ACTIVE",
       createdAt: chatDomain.createdAt,
     };

--- a/src/contexts/CoreContext/mappers/ChatMapper.ts
+++ b/src/contexts/CoreContext/mappers/ChatMapper.ts
@@ -1,0 +1,82 @@
+import { Chat } from "../domain/aggregates/Chat";
+import { Chat as ChatPrisma } from "@/generated/prisma";
+import { ChatDao } from "../domain/interfaces/dao/ChatDao";
+import { ChatDto } from "../domain/interfaces/dtos/IChatDto";
+import { MessageMapper } from "./MessageMapper";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { ChatName } from "../domain/valueObjects/ChatName";
+
+export class ChatMapper {
+  public static DtoToDomain(chatDto: ChatDto): Chat {
+    return Chat.create(
+      {
+        messages: MessageMapper.ManyDtoToDomain(chatDto.messages),
+        participantsIds: chatDto.participansIds.map(
+          (id) => new UniqueEntityID(id)
+        ),
+        createdAt: chatDto.createdAt,
+        name: ChatName.create(chatDto.name ?? ""),
+        status: chatDto.status,
+      },
+      new UniqueEntityID(chatDto.id)
+    );
+  }
+  public static DomainToDto(chatDomain: Chat): ChatDto {
+    return {
+      id: chatDomain.id.toString(),
+      name: chatDomain.chatName?.value,
+      messages: MessageMapper.ManyDomainToDto(chatDomain.messages),
+      participansIds: chatDomain.participantsIds.map((id) => id.toString()),
+      status: chatDomain.status ?? "ACTIVE",
+      createdAt: chatDomain.createdAt,
+    };
+  }
+
+  public static DomainToPersistence(chatDomain: Chat): ChatPrisma {
+    return {
+      id: chatDomain.id.toString(),
+      createdAt: chatDomain.createdAt ?? new Date(),
+      name: chatDomain.chatName?.value ?? "",
+      status: chatDomain.status ?? "ACTIVE",
+    };
+  }
+
+  public static PersistenceToDomain(chatDao: ChatDao): Chat {
+    return Chat.create(
+      {
+        name: ChatName.create(chatDao.name ?? ""),
+        messages: MessageMapper.ManyPersistenceToDomain(chatDao.messages),
+        participantsIds: chatDao.participantsIds.map(
+          (id) => new UniqueEntityID(id)
+        ),
+        createdAt: chatDao.createdAt,
+        status: chatDao.status,
+      },
+      new UniqueEntityID(chatDao.id)
+    );
+  }
+
+  public static ManyDtoToDomain(chatsDto: ChatDto[]): Chat[] {
+    return chatsDto.map((chat) => {
+      return this.DtoToDomain(chat);
+    });
+  }
+
+  public static ManyDomainToDto(chatsDomain: Chat[]): ChatDto[] {
+    return chatsDomain.map((chat) => {
+      return this.DomainToDto(chat);
+    });
+  }
+
+  public static ManyDomainToPersistence(chatsDomain: Chat[]): ChatPrisma[] {
+    return chatsDomain.map((chat) => {
+      return this.DomainToPersistence(chat);
+    });
+  }
+
+  public static ManyPersistenceToDomain(chatsDao: ChatDao[]): Chat[] {
+    return chatsDao.map((chat) => {
+      return this.PersistenceToDomain(chat);
+    });
+  }
+}

--- a/src/contexts/CoreContext/mappers/MessageMapper.ts
+++ b/src/contexts/CoreContext/mappers/MessageMapper.ts
@@ -1,0 +1,86 @@
+import { Message } from "../domain/entities/Message";
+import { Message as MessagePrisma } from "@/generated/prisma";
+import { MessageDto } from "../domain/interfaces/dtos/IMessageDto";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+
+export class MessageMapper {
+  public static DtoToDomain(messageDto: MessageDto): Message {
+    return Message.create(
+      {
+        chatId: new UniqueEntityID(messageDto.chatId),
+        content: messageDto.content,
+        senderId: new UniqueEntityID(messageDto.senderId),
+        timestamp: messageDto.timestamp,
+        type: messageDto.type,
+        status: messageDto.status,
+      },
+      new UniqueEntityID(messageDto.id)
+    );
+  }
+
+  public static DomainToDto(messageDomain: Message): MessageDto {
+    return {
+      id: messageDomain.id.toString(),
+      chatId: messageDomain.chatId.toString(),
+      content: messageDomain.content,
+      senderId: messageDomain.senderId.toString(),
+      status: messageDomain.status,
+      timestamp: messageDomain.timestamp,
+      type: messageDomain.type,
+    };
+  }
+
+  public static DomainToPersistence(messageDomain: Message): MessagePrisma {
+    return {
+      id: messageDomain.id.toString(),
+      chatId: messageDomain.chatId.toString(),
+      content: messageDomain.content,
+      senderId: messageDomain.senderId.toString(),
+      status: messageDomain.status,
+      timestamp: messageDomain.timestamp,
+      type: messageDomain.type,
+    };
+  }
+
+  public static PersistenceToDomain(messagePrisma: MessagePrisma): Message {
+    return Message.create(
+      {
+        chatId: new UniqueEntityID(messagePrisma.chatId),
+        content: messagePrisma.content,
+        senderId: new UniqueEntityID(messagePrisma.senderId),
+        timestamp: messagePrisma.timestamp,
+        type: messagePrisma.type,
+        status: messagePrisma.status,
+      },
+      new UniqueEntityID(messagePrisma.id)
+    );
+  }
+
+  public static ManyDtoToDomain(messagesDto: MessageDto[]): Message[] {
+    return messagesDto.map((message) => {
+      return this.DtoToDomain(message);
+    });
+  }
+
+  public static ManyDomainToDto(messagesDomain: Message[]): MessageDto[] {
+    return messagesDomain.map((message) => {
+      return this.DomainToDto(message);
+    });
+  }
+
+  public static ManyDomainToPersistence(
+    messagesDomain: Message[]
+  ): MessagePrisma[] {
+    return messagesDomain.map((message) => {
+      return this.DomainToPersistence(message);
+    });
+  }
+
+  public static ManyPersistenceToDomain(
+    messagesPrisma: MessagePrisma[]
+  ): Message[] {
+    return messagesPrisma.map((message) => {
+      return this.PersistenceToDomain(message);
+    });
+  }
+}

--- a/src/contexts/CoreContext/mappers/MessageMapper.ts
+++ b/src/contexts/CoreContext/mappers/MessageMapper.ts
@@ -2,6 +2,7 @@ import { Message } from "../domain/entities/Message";
 import { Message as MessagePrisma } from "@/generated/prisma";
 import { MessageDto } from "../domain/interfaces/dtos/IMessageDto";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { MessageDao } from "../domain/interfaces/dao/MessageDao";
 
 export class MessageMapper {
   public static DtoToDomain(messageDto: MessageDto): Message {
@@ -13,6 +14,8 @@ export class MessageMapper {
         timestamp: messageDto.timestamp,
         type: messageDto.type,
         status: messageDto.status,
+        receiversIds:
+          messageDto.receiversIds?.map((id) => new UniqueEntityID(id)) ?? [],
       },
       new UniqueEntityID(messageDto.id)
     );
@@ -27,10 +30,11 @@ export class MessageMapper {
       status: messageDomain.status,
       timestamp: messageDomain.timestamp,
       type: messageDomain.type,
+      receiversIds: messageDomain.receiversIds.map((id) => id.toString()),
     };
   }
 
-  public static DomainToPersistence(messageDomain: Message): MessagePrisma {
+  public static DomainToPersistence(messageDomain: Message): MessageDao {
     return {
       id: messageDomain.id.toString(),
       chatId: messageDomain.chatId.toString(),
@@ -39,10 +43,11 @@ export class MessageMapper {
       status: messageDomain.status,
       timestamp: messageDomain.timestamp,
       type: messageDomain.type,
+      receiversIds: messageDomain.receiversIds.map((id) => id.toString()),
     };
   }
 
-  public static PersistenceToDomain(messagePrisma: MessagePrisma): Message {
+  public static PersistenceToDomain(messagePrisma: MessageDao): Message {
     return Message.create(
       {
         chatId: new UniqueEntityID(messagePrisma.chatId),
@@ -51,6 +56,8 @@ export class MessageMapper {
         timestamp: messagePrisma.timestamp,
         type: messagePrisma.type,
         status: messagePrisma.status,
+        receiversIds:
+          messagePrisma.receiversIds?.map((id) => new UniqueEntityID(id)) ?? [],
       },
       new UniqueEntityID(messagePrisma.id)
     );
@@ -77,7 +84,7 @@ export class MessageMapper {
   }
 
   public static ManyPersistenceToDomain(
-    messagesPrisma: MessagePrisma[]
+    messagesPrisma: MessageDao[]
   ): Message[] {
     return messagesPrisma.map((message) => {
       return this.PersistenceToDomain(message);

--- a/src/contexts/CoreContext/mappers/UserMapper.ts
+++ b/src/contexts/CoreContext/mappers/UserMapper.ts
@@ -30,6 +30,7 @@ export default class UserMapper {
       profilePicture: user.profilePicture ?? null,
       roles: roles2,
       createdAt: user.createdAt,
+      lastSeen: user.lastSeen ?? new Date(),
     };
   }
 

--- a/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
@@ -17,7 +17,8 @@ export class ChatController implements IChatController {
   ) {}
   create = async (req: Request, res: Response): Promise<void> => {
     try {
-      const chatDto = req.body as ChatDto;
+      const chat = req.body as ChatDto;
+      const chatDto: ChatDto = { ...chat, messages: [], status: "ACTIVE" };
       const chatDomain = ChatMapper.DtoToDomain(chatDto);
       const newChatDomain = await this.chatService.create(chatDomain);
       const newChatDto = ChatMapper.DomainToDto(newChatDomain);

--- a/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
@@ -16,21 +16,31 @@ export class ChatController implements IChatController {
     private chatService: IChatService
   ) {}
   create = async (req: Request, res: Response): Promise<void> => {
-    try {
-      const chat = req.body as ChatDto;
-      const chatDto: ChatDto = { ...chat, messages: [], status: "ACTIVE" };
-      const chatDomain = ChatMapper.DtoToDomain(chatDto);
-      const newChatDomain = await this.chatService.create(chatDomain);
-      const newChatDto = ChatMapper.DomainToDto(newChatDomain);
-      const response = new SuccessResponseEntity(
-        newChatDto,
-        StatusCodes.CREATED,
-        "Chat saved successfully"
-      );
-      ResponseService.send(res, response);
-    } catch (error) {
-      console.log(error);
-      throw new ApiError();
-    }
+    const chat = req.body as ChatDto;
+    console.log(chat);
+
+    const chatDto: ChatDto = { ...chat, messages: [], status: "ACTIVE" };
+    const chatDomain = ChatMapper.DtoToDomain(chatDto);
+    const newChatDomain = await this.chatService.create(chatDomain);
+    const newChatDto = ChatMapper.DomainToDto(newChatDomain);
+    const response = new SuccessResponseEntity(
+      newChatDto,
+      StatusCodes.CREATED,
+      "Chat saved successfully"
+    );
+    ResponseService.send(res, response);
+  };
+  get = async (req: Request, res: Response): Promise<void> => {
+    const { chatId } = req.params;
+    const chatDomain = await this.chatService.get(chatId);
+    if (!chatDomain)
+      throw new ApiError(StatusCodes.NOT_FOUND, "Chat not found");
+    const chatDto = ChatMapper.DomainToDto(chatDomain);
+    const response = new SuccessResponseEntity(
+      chatDto,
+      StatusCodes.OK,
+      "Chat retrieved successfully"
+    );
+    ResponseService.send(res, response);
   };
 }

--- a/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/ChatController.ts
@@ -1,0 +1,35 @@
+import { IChatController } from "@/contexts/CoreContext/domain/interfaces/controllers/IChatController";
+import { ChatDto } from "@/contexts/CoreContext/domain/interfaces/dtos/IChatDto";
+import { IChatService } from "@/contexts/CoreContext/domain/interfaces/services/IChatService";
+import { ChatMapper } from "@/contexts/CoreContext/mappers/ChatMapper";
+import { ResponseService } from "@/contexts/Shared/application/services/ResponseService";
+import { SuccessResponseEntity } from "@/contexts/Shared/domain/entity/SuccessResponseEntity";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class ChatController implements IChatController {
+  constructor(
+    @inject("IChatService")
+    private chatService: IChatService
+  ) {}
+  create = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const chatDto = req.body as ChatDto;
+      const chatDomain = ChatMapper.DtoToDomain(chatDto);
+      const newChatDomain = await this.chatService.create(chatDomain);
+      const newChatDto = ChatMapper.DomainToDto(newChatDomain);
+      const response = new SuccessResponseEntity(
+        newChatDto,
+        StatusCodes.CREATED,
+        "Chat saved successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  };
+}

--- a/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
@@ -17,7 +17,12 @@ export class MessageController implements IMessageController {
   ) {}
   create = async (req: Request, res: Response): Promise<void> => {
     try {
-      const messageDto = req.body as MessageDto;
+      const message = req.body;
+      const messageDto: MessageDto = {
+        ...message,
+        status: "SENT",
+        timestamp: message.timestamp ?? new Date(),
+      };
       const messageDomain = MessageMapper.DtoToDomain(messageDto);
       const newMessageDomain = await this.messageService.create(messageDomain);
       const newMessageDto = MessageMapper.DomainToDto(newMessageDomain);

--- a/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
@@ -21,7 +21,7 @@ export class MessageController implements IMessageController {
       const messageDto: MessageDto = {
         ...message,
         status: "SENT",
-        timestamp: message.timestamp ?? new Date(),
+        timestamp: new Date(message.timestamp),
       };
       const messageDomain = MessageMapper.DtoToDomain(messageDto);
       const newMessageDomain = await this.messageService.create(messageDomain);

--- a/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
@@ -1,0 +1,68 @@
+import { IMessageController } from "@/contexts/CoreContext/domain/interfaces/controllers/IMessageController";
+import { MessageDto } from "@/contexts/CoreContext/domain/interfaces/dtos/IMessageDto";
+import { IMessageService } from "@/contexts/CoreContext/domain/interfaces/services/IMessageService";
+import { MessageMapper } from "@/contexts/CoreContext/mappers/MessageMapper";
+import { ResponseService } from "@/contexts/Shared/application/services/ResponseService";
+import { SuccessResponseEntity } from "@/contexts/Shared/domain/entity/SuccessResponseEntity";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class MessageController implements IMessageController {
+  constructor(
+    @inject("IMessageService")
+    private messageService: IMessageService
+  ) {}
+  create = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const messageDto = req.body as MessageDto;
+      const messageDomain = MessageMapper.DtoToDomain(messageDto);
+      const newMessageDomain = await this.messageService.create(messageDomain);
+      const newMessageDto = MessageMapper.DomainToDto(newMessageDomain);
+      const response = new SuccessResponseEntity(
+        newMessageDto,
+        StatusCodes.CREATED,
+        "Message saved successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  };
+  getMessagesByChatId = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { chatId } = req.params;
+      if (!chatId)
+        throw new ApiError(StatusCodes.BAD_REQUEST, "Chat id is missing");
+      const messagesDomain = await this.messageService.getManyByChatId(chatId);
+      const messagesDto = MessageMapper.ManyDomainToDto(messagesDomain);
+      const response = new SuccessResponseEntity(
+        messagesDto,
+        StatusCodes.OK,
+        "Messages retrieved successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  };
+  updateMessageStatus = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { chatId, userId } = req.params;
+      await this.messageService.markManyAsRead(chatId, userId);
+      const response = new SuccessResponseEntity(
+        null,
+        StatusCodes.NO_CONTENT,
+        "Messages marked as read successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  };
+}

--- a/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/MessageController.ts
@@ -16,44 +16,33 @@ export class MessageController implements IMessageController {
     private messageService: IMessageService
   ) {}
   create = async (req: Request, res: Response): Promise<void> => {
-    try {
-      const message = req.body;
-      const messageDto: MessageDto = {
-        ...message,
-        status: "SENT",
-        timestamp: new Date(message.timestamp),
-      };
-      const messageDomain = MessageMapper.DtoToDomain(messageDto);
-      const newMessageDomain = await this.messageService.create(messageDomain);
-      const newMessageDto = MessageMapper.DomainToDto(newMessageDomain);
-      const response = new SuccessResponseEntity(
-        newMessageDto,
-        StatusCodes.CREATED,
-        "Message saved successfully"
-      );
-      ResponseService.send(res, response);
-    } catch (error) {
-      console.log(error);
-      throw new ApiError();
-    }
+    const message = req.body;
+    const messageDto: MessageDto = {
+      ...message,
+      timestamp: new Date(message.timestamp),
+    };
+    const messageDomain = MessageMapper.DtoToDomain(messageDto);
+    const newMessageDomain = await this.messageService.create(messageDomain);
+    const newMessageDto = MessageMapper.DomainToDto(newMessageDomain);
+    const response = new SuccessResponseEntity(
+      newMessageDto,
+      StatusCodes.CREATED,
+      "Message saved successfully"
+    );
+    ResponseService.send(res, response);
   };
   getMessagesByChatId = async (req: Request, res: Response): Promise<void> => {
-    try {
-      const { chatId } = req.params;
-      if (!chatId)
-        throw new ApiError(StatusCodes.BAD_REQUEST, "Chat id is missing");
-      const messagesDomain = await this.messageService.getManyByChatId(chatId);
-      const messagesDto = MessageMapper.ManyDomainToDto(messagesDomain);
-      const response = new SuccessResponseEntity(
-        messagesDto,
-        StatusCodes.OK,
-        "Messages retrieved successfully"
-      );
-      ResponseService.send(res, response);
-    } catch (error) {
-      console.log(error);
-      throw new ApiError();
-    }
+    const { chatId } = req.params;
+    if (!chatId)
+      throw new ApiError(StatusCodes.BAD_REQUEST, "Chat id is missing");
+    const messagesDomain = await this.messageService.getManyByChatId(chatId);
+    const messagesDto = MessageMapper.ManyDomainToDto(messagesDomain);
+    const response = new SuccessResponseEntity(
+      messagesDto,
+      StatusCodes.OK,
+      "Messages retrieved successfully"
+    );
+    ResponseService.send(res, response);
   };
   updateMessageStatus = async (req: Request, res: Response): Promise<void> => {
     try {

--- a/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
@@ -21,20 +21,20 @@ export class UserController implements IUserController {
     private chatService: IChatService
   ) {}
   getChats = async (req: Request, res: Response): Promise<void> => {
-    try {
-      const { id } = req.params;
-      const chats = await this.chatService.getManyByUserId(id);
-      const chatsDto = ChatMapper.ManyDomainToDto(chats);
-      const response = new SuccessResponseEntity(
-        chatsDto,
-        StatusCodes.OK,
-        "Chats retrieved successfully"
-      );
-      ResponseService.send(res, response);
-    } catch (error) {
-      console.log(error);
-      throw new ApiError();
-    }
+    // try {
+    const { userId } = req.params;
+    const chats = await this.chatService.getManyByUserId(userId);
+    const chatsDto = ChatMapper.ManyDomainToDto(chats);
+    const response = new SuccessResponseEntity(
+      chatsDto,
+      StatusCodes.OK,
+      "Chats retrieved successfully"
+    );
+    ResponseService.send(res, response);
+    // } catch (error) {
+    //   console.log(error);
+    //   throw new ApiError();
+    // }
   };
 
   freelance = async (req: Request, res: Response) => {

--- a/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
@@ -1,7 +1,9 @@
 import { User } from "@/contexts/CoreContext/domain/aggregates/User";
 import { IUserController } from "@/contexts/CoreContext/domain/interfaces/controllers/IUserController";
 import { ICreateUserDto } from "@/contexts/CoreContext/domain/interfaces/dtos/ICreateUserDto";
+import { IChatService } from "@/contexts/CoreContext/domain/interfaces/services/IChatService";
 import { IUserService } from "@/contexts/CoreContext/domain/interfaces/services/IUserService";
+import { ChatMapper } from "@/contexts/CoreContext/mappers/ChatMapper";
 import UserMapper from "@/contexts/CoreContext/mappers/UserMapper";
 import { ResponseService } from "@/contexts/Shared/application/services/ResponseService";
 import { SuccessResponseEntity } from "@/contexts/Shared/domain/entity/SuccessResponseEntity";
@@ -14,8 +16,26 @@ import { inject, injectable } from "tsyringe";
 export class UserController implements IUserController {
   constructor(
     @inject("IUserService")
-    private userService: IUserService
+    private userService: IUserService,
+    @inject("IChatService")
+    private chatService: IChatService
   ) {}
+  getChats = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const chats = await this.chatService.getManyByUserId(id);
+      const chatsDto = ChatMapper.ManyDomainToDto(chats);
+      const response = new SuccessResponseEntity(
+        chatsDto,
+        StatusCodes.OK,
+        "Chats retrieved successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.log(error);
+      throw new ApiError();
+    }
+  };
 
   freelance = async (req: Request, res: Response) => {
     const userId = req.user?.id ?? req.params.id;

--- a/src/contexts/CoreContext/presentation/http/routes/ChatRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/ChatRoutes.ts
@@ -20,6 +20,10 @@ const messageController = container.resolve(MessageController);
  *         application/x-www-form-urlencoded:
  *           schema:
  *             $ref: '#/components/schemas/Chat'
+ *           encoding:
+ *             participantsIds:
+ *               style: form
+ *               explode: true
  *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/Chat'
@@ -31,6 +35,31 @@ const messageController = container.resolve(MessageController);
  *
  */
 chatRoutes.post("", chatController.create);
+
+/**
+ * @openapi
+ * /chats/{chatId}:
+ *   get:
+ *     summary: Get chat information
+ *     tags:
+ *       - Chat
+ *     parameters:
+ *       - in: path
+ *         name: chatId
+ *         required: true
+ *         description: The ID of the chat
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Chat retrieved successfully
+ *       404:
+ *         description: Chat not found
+ *       500:
+ *         description: Server error
+ *
+ */
+chatRoutes.get("/:chatId", chatController.get);
 
 /**
  * @openapi
@@ -48,9 +77,9 @@ chatRoutes.post("", chatController.create);
  *           type: string
  *     responses:
  *       200:
- *         description: Chats found
+ *         description: Messages retrieved successfully
  *       404:
- *         description: Chats not found
+ *         description: Chat not found
  *       500:
  *         description: Server error
  *
@@ -84,7 +113,7 @@ chatRoutes.get("/:chatId/messages", messageController.getMessagesByChatId);
  *       201:
  *         description: Message created successfully
  *       404:
- *         description: chat not found
+ *         description: Resource not found
  *       500:
  *         description: Server error
  *
@@ -138,6 +167,7 @@ chatRoutes.put(
  *           type: array
  *           items:
  *             type: string
+ *             format: uuid
  *           description: The Ids of the users participants of the chat
  *       required:
  *         - participantsIds
@@ -145,6 +175,10 @@ chatRoutes.put(
  *     Message:
  *       type: object
  *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *           description: Id of the message
  *         content:
  *           type: string
  *           description: Content of the message
@@ -162,9 +196,11 @@ chatRoutes.put(
  *           description: Time when the message has been sent
  *         senderId:
  *           type: string
+ *           format: uuid
  *           description: Id of the user who sent the message
  *         chatId:
  *           type: string
+ *           format: uuid
  *           description: Id of the chat
  *       required:
  *         - content

--- a/src/contexts/CoreContext/presentation/http/routes/ChatRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/ChatRoutes.ts
@@ -1,0 +1,175 @@
+import { Router } from "express";
+import { container } from "@/di-container";
+import { ChatController } from "../controllers/ChatController";
+import { MessageController } from "../controllers/MessageController";
+
+export const chatRoutes = Router({ mergeParams: true });
+const chatController = container.resolve(ChatController);
+const messageController = container.resolve(MessageController);
+
+/**
+ * @openapi
+ * /chats:
+ *  post:
+ *      summary: Create a new chat between users
+ *      tags:
+ *       - Chat
+ *      requestBody:
+ *       required: true
+ *       content:
+ *         application/x-www-form-urlencoded:
+ *           schema:
+ *             $ref: '#/components/schemas/Chat'
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Chat'
+ *      responses:
+ *          201:
+ *              description: Everything is ok and returns new chat
+ *          500:
+ *              description: Everything is wrong
+ *
+ */
+chatRoutes.post("", chatController.create);
+
+/**
+ * @openapi
+ * /chats/{chatId}/messages:
+ *   get:
+ *     summary: Get chat messages
+ *     tags:
+ *       - Chat
+ *     parameters:
+ *       - in: path
+ *         name: chatId
+ *         required: true
+ *         description: The ID of the chat
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Chats found
+ *       404:
+ *         description: Chats not found
+ *       500:
+ *         description: Server error
+ *
+ */
+chatRoutes.get("/:chatId/messages", messageController.getMessagesByChatId);
+
+/**
+ * @openapi
+ * /chats/{chatId}/messages:
+ *   post:
+ *     summary: Create chat message
+ *     tags:
+ *       - Chat
+ *     parameters:
+ *       - in: path
+ *         name: chatId
+ *         required: true
+ *         description: The ID of the chat
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/x-www-form-urlencoded:
+ *           schema:
+ *             $ref: '#/components/schemas/Message'
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Message'
+ *     responses:
+ *       201:
+ *         description: Message created successfully
+ *       404:
+ *         description: chat not found
+ *       500:
+ *         description: Server error
+ *
+ */
+chatRoutes.post("/:chatId/messages", messageController.create);
+
+/**
+ * @openapi
+ * /chats/{chatId}/users/{userId}/messages/status:
+ *   put:
+ *     summary: Update the status of messages in chat
+ *     tags:
+ *       - Chat
+ *     parameters:
+ *       - in: path
+ *         name: chatId
+ *         required: true
+ *         description: The ID of the chat
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: userId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The ID of the user who has seen the messages
+ *     responses:
+ *       204:
+ *         description: Message status in chat updated successfully
+ *       500:
+ *         description: Server error
+ *
+ */
+chatRoutes.put(
+  "/:chatId/users/:userId/messages/status",
+  messageController.updateMessageStatus
+);
+
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Chat:
+ *       type: object
+ *       properties:
+ *         name:
+ *           type: string
+ *           description: Name of the chat to display
+ *           example: "Awesome chat"
+ *         participantsIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: The Ids of the users participants of the chat
+ *       required:
+ *         - participantsIds
+ *
+ *     Message:
+ *       type: object
+ *       properties:
+ *         content:
+ *           type: string
+ *           description: Content of the message
+ *           example: "This is my first message!"
+ *         type:
+ *           type: string
+ *           description: Type of sent message
+ *           example: "TEXT"
+ *           default: "TEXT"
+ *           enum:
+ *             - TEXT
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *           description: Time when the message has been sent
+ *         senderId:
+ *           type: string
+ *           description: Id of the user who sent the message
+ *         chatId:
+ *           type: string
+ *           description: Id of the chat
+ *       required:
+ *         - content
+ *         - type
+ *         - timestamp
+ *         - senderId
+ *         - chatId
+ */

--- a/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
@@ -110,6 +110,29 @@ router.patch("/", verifyToken(), controller.updateUser);
  */
 router.put("/:id/freelance", controller.freelance);
 
+/**
+ * @openapi
+ * /users/{id}/chats:
+ *  get:
+ *     summary: Get the chats of the user with id
+ *     tags:
+ *       - User
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the user
+ *         schema:
+ *           type: string
+ *     responses:
+ *          200:
+ *              description: Everything is ok and returns the user chats
+ *          500:
+ *              description: Everything is wrong
+ *
+ */
+router.get("/:userId/chats", controller.getChats);
+
 export default router;
 
 /**

--- a/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
@@ -124,9 +124,12 @@ router.put("/:id/freelance", controller.freelance);
  *         description: The ID of the user
  *         schema:
  *           type: string
+ *           format: uuid
  *     responses:
  *          200:
  *              description: Everything is ok and returns the user chats
+ *          404:
+ *              description: User not found
  *          500:
  *              description: Everything is wrong
  *

--- a/src/di-container.ts
+++ b/src/di-container.ts
@@ -116,6 +116,7 @@ import { IChatRepository } from "./contexts/CoreContext/domain/interfaces/reposi
 import { ChatRepository } from "./contexts/CoreContext/infrastructure/persistence/ChatRepository";
 import { IMessageRepository } from "./contexts/CoreContext/domain/interfaces/repositories/IMessageRepository";
 import { MessageRepository } from "./contexts/CoreContext/infrastructure/persistence/MessageRepository";
+import { GetChatByIdUseCase } from "./contexts/CoreContext/application/useCases/chats/GetChatByIdUseCase";
 
 //User
 container.registerSingleton<IUserRepository>("IUserRepository", UserRepository);
@@ -404,6 +405,10 @@ container.registerSingleton<IMessageService>("IMessageService", MessageService);
 container.registerSingleton<IUseCase<Chat, Chat>>(
   "CreateChatUseCase",
   CreateChatUsecase
+);
+container.registerSingleton<IUseCase<string, Chat>>(
+  "GetChatByIdUseCase",
+  GetChatByIdUseCase
 );
 container.registerSingleton<IUseCase<Message, Message>>(
   "CreateMessageUseCase",

--- a/src/di-container.ts
+++ b/src/di-container.ts
@@ -99,6 +99,23 @@ import { IExternarlAuthService } from "./contexts/CoreContext/domain/interfaces/
 import { KeycloakService } from "./contexts/CoreContext/infrastructure/keycloak/keycloakService";
 import { SyncUserUseCase } from "./contexts/CoreContext/application/useCases/auth/SyncUserUseCase";
 import { IAuthService } from "./contexts/CoreContext/domain/interfaces/services/IAuthService";
+import { IChatController } from "./contexts/CoreContext/domain/interfaces/controllers/IChatController";
+import { ChatController } from "./contexts/CoreContext/presentation/http/controllers/ChatController";
+import { IChatService } from "./contexts/CoreContext/domain/interfaces/services/IChatService";
+import { ChatService } from "./contexts/CoreContext/application/services/ChatService";
+import { IMessageService } from "./contexts/CoreContext/domain/interfaces/services/IMessageService";
+import { MessageService } from "./contexts/CoreContext/application/services/MessageService";
+import { CreateChatUsecase } from "./contexts/CoreContext/application/useCases/chats/CreateChatUseCase";
+import { CreateMessageUseCase } from "./contexts/CoreContext/application/useCases/chats/CreateMessageUseCase";
+import { GetChatsByUserIdUseCase } from "./contexts/CoreContext/application/useCases/chats/GetChatsByUserIdUseCase";
+import { GetMessagesByChatIdUseCase } from "./contexts/CoreContext/application/useCases/chats/GetMessagesByChatIdUseCase";
+import { UpdateMessageStatusUseCase } from "./contexts/CoreContext/application/useCases/chats/UpdateMessageStatusUseCase";
+import { Chat } from "./contexts/CoreContext/domain/aggregates/Chat";
+import { Message } from "./contexts/CoreContext/domain/entities/Message";
+import { IChatRepository } from "./contexts/CoreContext/domain/interfaces/repositories/IChatRepository";
+import { ChatRepository } from "./contexts/CoreContext/infrastructure/persistence/ChatRepository";
+import { IMessageRepository } from "./contexts/CoreContext/domain/interfaces/repositories/IMessageRepository";
+import { MessageRepository } from "./contexts/CoreContext/infrastructure/persistence/MessageRepository";
 
 //User
 container.registerSingleton<IUserRepository>("IUserRepository", UserRepository);
@@ -376,6 +393,39 @@ container.registerSingleton<IUseCase<{ user: User; role: string }, void>>(
 container.registerSingleton<IExternarlAuthService>(
   "IAuthManagerService",
   KeycloakService
+);
+
+// Chats
+container.registerSingleton<IChatController>("ChatController", ChatController);
+
+container.registerSingleton<IChatService>("IChatService", ChatService);
+container.registerSingleton<IMessageService>("IMessageService", MessageService);
+
+container.registerSingleton<IUseCase<Chat, Chat>>(
+  "CreateChatUseCase",
+  CreateChatUsecase
+);
+container.registerSingleton<IUseCase<Message, Message>>(
+  "CreateMessageUseCase",
+  CreateMessageUseCase
+);
+container.registerSingleton<IUseCase<string, Chat[]>>(
+  "GetChatsByUserIdUseCase",
+  GetChatsByUserIdUseCase
+);
+container.registerSingleton<IUseCase<string, Message[]>>(
+  "GetMessagesByChatIdUseCase",
+  GetMessagesByChatIdUseCase
+);
+container.registerSingleton<IUseCase<{ chatId: string; userId: string }, void>>(
+  "UpdateMessageStatusUseCase",
+  UpdateMessageStatusUseCase
+);
+
+container.registerSingleton<IChatRepository>("IChatRepository", ChatRepository);
+container.registerSingleton<IMessageRepository>(
+  "IMessageRepository",
+  MessageRepository
 );
 
 export { container };

--- a/tests/contexts/coreContext/presentation/http/controllers/AuthController.updateUserRoles.spec.ts
+++ b/tests/contexts/coreContext/presentation/http/controllers/AuthController.updateUserRoles.spec.ts
@@ -62,7 +62,7 @@ describe("AuthController - updateUserRoles", () => {
   it("should throw UNAUTHORIZED if req.user is missing", async () => {
     req = {
       user: undefined,
-      body: { role: "admin" },
+      body: { role: "admin", lastSeen: new Date() },
     } as Partial<Request> as Request;
 
     await controller.updateUserRoles(req, res);


### PR DESCRIPTION
## Description

This feature creates workflows to handle chats and messages in API adding the needed objects

## Main Changes

- Create Chat and Message aggregates
- Create Chat and Message mappers with the next functions:
-   DtoToDomain
-   DomainToDto
-   DomainToPersistence
-   PersistenceToDomain
-   ManyDtoToDomain
-   ManyDomainToDto
-   ManyDomainToPersistence
-   ManyPersistenceToDomain
- Create Dto objects for Chat and Message
- Create repositories and interfaces for repositories to Chat and Message
- Create use cases:
-   CreateChatUseCasesUseCase
-   GetMessagesByChatIdUseCase
-   CreateMessageUseCase
-   UpdateMessageStatusUseCase
-   GetChatsByUserIdUseCase
- Create services and interface for services to Chat and Message
- Create controllers and interface controllers for Chat and Message
- Create endpoints to handle chats persistence:
-   POST /chats -> Create a new chat
-   GET /chats/:chatId/messages -> Get all messages of a chat
-   POST /chats/:chatId/messages -> Save a message in DB
-   PUT /chats/:chatId/user/:userId/messages/status -> Update status of a all messages of the user in chat
-   GET /users/:userId/chats -> Get all chats of the user
- Documented all the endpoints in swagger

## Reviewers

@LucasMezzaJalaUniversity
@JoseCaJala
@cclaurevju
@ArielMonroy392
@MauricioLSalles
@ElamCanoJala
@AndreCarpio
@DanielRios491
@eduSpinouza
