### PR TITLE
feature: add endpoints to get and update a client

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import courseRoutes from "./contexts/LearningContext/presentation/http/routes/Co
 import { ErrorHandlerMiddleware } from "./contexts/Shared/infrastructure/middlewares/ErrorHandlerMiddleware";
 import userRoutes from "./contexts/CoreContext/presentation/http/routes/UserRoutes";
 import authRoutes from "./contexts/CoreContext/presentation/http/routes/AuthRoutes";
+import clientRoutes from "./contexts/CoreContext/presentation/http/routes/ClientRoutes";
 import swaggerUi from "swagger-ui-express";
 import { swaggerDocs } from "./config/swagger";
 
@@ -29,6 +30,7 @@ app.use("/api/health", healthRoutes);
 
 app.use("/api/users", userRoutes);
 app.use("/api/freelancers", freelancersRoutes);
+app.use("/api/clients", clientRoutes);
 
 app.use("/api/courses", courseRoutes);
 

--- a/src/contexts/CoreContext/application/services/ClientService.ts
+++ b/src/contexts/CoreContext/application/services/ClientService.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from "tsyringe";
+import { IClientService } from "../../domain/interfaces/services/IClientService";
+import { Client } from "../../domain/aggregates/Client";
+import { GetClientUseCase } from "../useCases/client/GetClientUseCase";
+import { UpdateClientUseCase } from "../useCases/client/UpdateClientUseCase";
+
+@injectable()
+export default class ClientService implements IClientService {
+  constructor(
+    @inject("GetClientUseCase")
+    private readonly getClientsUseCase: GetClientUseCase,
+    @inject("UpdateClientUseCase")
+    private readonly updateClientUseCase: UpdateClientUseCase
+  ) {}
+
+  async get(clientId: string): Promise<Client | null> {
+    return await this.getClientsUseCase.execute(clientId);
+  }
+
+  async update(clientId: string, clientData: Client): Promise<Client> {
+    return this.updateClientUseCase.execute({
+      clientId,
+      clientData,
+    });
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/client/GetClientUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/client/GetClientUseCase.ts
@@ -10,9 +10,9 @@ export class GetClientUseCase {
     @inject("IClientRepository")
     private readonly clientRepository: IClientRepository
   ) {}
-  async execute(clientId: string): Promise<Client | null> {
+  async execute(clientId: string): Promise<Client> {
     try {
-      const client: Client | null =
+      const client: Client =
         await this.clientRepository.getClientProfileById(clientId);
       if (client === null) {
         throw new ApiError(StatusCodes.NOT_FOUND, "Client not found.");

--- a/src/contexts/CoreContext/application/useCases/client/GetClientUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/client/GetClientUseCase.ts
@@ -1,0 +1,33 @@
+import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
+import { IClientRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class GetClientUseCase {
+  constructor(
+    @inject("IClientRepository")
+    private readonly clientRepository: IClientRepository
+  ) {}
+  async execute(clientId: string): Promise<Client | null> {
+    try {
+      const client: Client | null =
+        await this.clientRepository.getClientProfileById(clientId);
+      if (client === null) {
+        throw new ApiError(StatusCodes.NOT_FOUND, "Client not found.");
+      } else {
+        return client;
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      } else {
+        throw new ApiError(
+          StatusCodes.INTERNAL_SERVER_ERROR,
+          "server error in get client use case"
+        );
+      }
+    }
+  }
+}

--- a/src/contexts/CoreContext/application/useCases/client/UpdateClientUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/client/UpdateClientUseCase.ts
@@ -1,0 +1,39 @@
+import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
+import { IClientRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
+import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class UpdateClientUseCase
+  implements IUseCase<{ clientId: string; clientData: Client }, Client>
+{
+  constructor(
+    @inject("IClientRepository")
+    private readonly clientRepository: IClientRepository
+  ) {}
+  async execute({
+    clientId,
+    clientData,
+  }: {
+    clientId: string;
+    clientData: Client;
+  }): Promise<Client> {
+    const client = await this.clientRepository.getClientProfileById(clientId);
+    if (!client) throw new Error("Client not found");
+
+    Object.assign(client, clientData);
+    console.log(client, clientData, "DDSSSD");
+    const updatedClient = await this.clientRepository.updateClientProfile(
+      clientId,
+      client
+    );
+    if (!updatedClient)
+      throw new ApiError(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        "Error while updating client"
+      );
+    return updatedClient;
+  }
+}

--- a/src/contexts/CoreContext/domain/interfaces/controllers/IClientController.ts
+++ b/src/contexts/CoreContext/domain/interfaces/controllers/IClientController.ts
@@ -1,0 +1,6 @@
+import { Request, Response } from "express";
+
+export interface IClientController {
+  get(req: Request, res: Response): void;
+  update(req: Request, res: Response): void;
+}

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IClientProfileDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IClientProfileDto.ts
@@ -1,0 +1,11 @@
+import ISocialLinkDto from "./ISocialLinkDto";
+export interface IClientProfileDto {
+  userId: string;
+  id?: string;
+  phoneNumber: string | undefined;
+  country: string | undefined;
+  city: string | undefined;
+  gender: string | undefined;
+  dateOfBirth: Date | undefined;
+  socialLinks: ISocialLinkDto[] | undefined;
+}

--- a/src/contexts/CoreContext/domain/interfaces/dtos/ISocialLinkDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/ISocialLinkDto.ts
@@ -1,0 +1,4 @@
+export default interface ISocialLinkDto {
+  platform: "LINKEDIN" | "YOUTUBE" | "FACEBOOK" | "INSTAGRAM";
+  url: string;
+}

--- a/src/contexts/CoreContext/domain/interfaces/repositories/IClientRepository.ts
+++ b/src/contexts/CoreContext/domain/interfaces/repositories/IClientRepository.ts
@@ -1,5 +1,5 @@
-import { IRepository } from "@/contexts/Shared/domain/repository/IRepository";
 import { Client } from "../../aggregates/Client";
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface IClientRepository extends IRepository<Client> {}
+export interface IClientRepository {
+  getClientProfileById(id: string): Promise<Client | null>;
+  updateClientProfile(clientId: string, clientProfile: Client): Promise<Client>;
+}

--- a/src/contexts/CoreContext/domain/interfaces/repositories/IClientRepository.ts
+++ b/src/contexts/CoreContext/domain/interfaces/repositories/IClientRepository.ts
@@ -1,5 +1,5 @@
 import { Client } from "../../aggregates/Client";
 export interface IClientRepository {
-  getClientProfileById(id: string): Promise<Client | null>;
+  getClientProfileById(id: string): Promise<Client>;
   updateClientProfile(clientId: string, clientProfile: Client): Promise<Client>;
 }

--- a/src/contexts/CoreContext/domain/interfaces/services/IClientService.ts
+++ b/src/contexts/CoreContext/domain/interfaces/services/IClientService.ts
@@ -1,0 +1,6 @@
+import { Client } from "../../aggregates/Client";
+
+export interface IClientService {
+  get(clientId: string): Promise<Client | null>;
+  update(clientId: string, clientProfile: Client): Promise<Client>;
+}

--- a/src/contexts/CoreContext/domain/valueObjects/PhoneNumber.ts
+++ b/src/contexts/CoreContext/domain/valueObjects/PhoneNumber.ts
@@ -16,7 +16,8 @@ export class PhoneNumber extends ValueObject<PhoneNumberProps> {
   }
 
   private static isValidPhoneNumber(phone: string): boolean {
-    const regex = /^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}$/;
+    const regex =
+      /^(\+?\d{1,4}[\s.-]?)?(\(?\d{2,4}\)?[\s.-]?)?(\d{3,4}[\s.-]?\d{4})$/;
     return regex.test(phone);
   }
 

--- a/src/contexts/CoreContext/domain/valueObjects/SocialLink.ts
+++ b/src/contexts/CoreContext/domain/valueObjects/SocialLink.ts
@@ -3,12 +3,12 @@ import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import { StatusCodes } from "http-status-codes";
 
 interface SocialLinkProps {
-  platform: "linkedin" | "youtube" | "facebook" | "instagram";
+  platform: "LINKEDIN" | "YOUTUBE" | "FACEBOOK" | "INSTAGRAM";
   url: string;
 }
 
 export class SocialLink extends ValueObject<SocialLinkProps> {
-  get platform(): "linkedin" | "youtube" | "facebook" | "instagram" {
+  get platform(): "LINKEDIN" | "YOUTUBE" | "FACEBOOK" | "INSTAGRAM" {
     return this.props.platform;
   }
 
@@ -26,7 +26,7 @@ export class SocialLink extends ValueObject<SocialLinkProps> {
   }
 
   private static isValidPlatform(value: string): boolean {
-    const validPlatforms = ["linkedin", "youtube", "facebook", "instagram"];
+    const validPlatforms = ["LINKEDIN", "YOUTUBE", "FACEBOOK", "INSTAGRAM"];
     return validPlatforms.some((platform) => value === platform);
   }
 

--- a/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
@@ -1,0 +1,92 @@
+import { Client } from "../../domain/aggregates/Client";
+import { IClientRepository } from "../../domain/interfaces/repositories/IClientRepository";
+import prismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient";
+import { injectable } from "tsyringe";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { StatusCodes } from "http-status-codes";
+import ClientMapper from "../../mappers/ClientMapper";
+import { IClientProfileDto } from "../../domain/interfaces/dtos/IClientProfileDto";
+
+@injectable()
+export class ClientRepository implements IClientRepository {
+  async getClientProfileById(id: string): Promise<Client | null> {
+    const clientProfile = await prismaClient.client.findUnique({
+      where: { id },
+      include: { socialLink: true },
+    });
+
+    if (!clientProfile) {
+      throw new ApiError(StatusCodes.NOT_FOUND, "The client doesn't exist");
+    }
+
+    // Adapt prisma object to dto
+    const clientProfileDto: IClientProfileDto = {
+      id: clientProfile.id, //check this id here an in ClientMapper
+      userId: clientProfile.userId,
+      phoneNumber: clientProfile.phoneNumber || undefined,
+      country: clientProfile.country || undefined,
+      city: clientProfile.city || undefined,
+      gender: clientProfile.gender || undefined,
+      dateOfBirth: clientProfile.dateOfBirth || undefined,
+      socialLinks: clientProfile.socialLink.map((link) => ({
+        id: link.id,
+        platform: link.platform,
+        url: link.url,
+      })),
+    };
+
+    return ClientMapper.persistanceTodomain(clientProfileDto);
+  }
+
+  async updateClientProfile(clientId: string, client: Client): Promise<Client> {
+    try {
+      const clientDto = ClientMapper.domainToGetClientDto(client);
+
+      const updatedClient = await prismaClient.client.update({
+        where: { id: clientId },
+        data: {
+          phoneNumber: clientDto.phoneNumber ?? "",
+          city: clientDto.city ?? "",
+          country: clientDto.country ?? "",
+          gender: clientDto.gender ?? "",
+          dateOfBirth: clientDto.dateOfBirth ?? null,
+          socialLink: {
+            deleteMany: {}, // this replace previous links each time
+            create:
+              clientDto.socialLinks?.map((link) => ({
+                platform: link.platform,
+                url: link.url,
+              })) || [],
+          },
+        },
+        include: {
+          socialLink: true,
+        },
+      });
+
+      // Map prisma to clientprofiledto
+      const updatedClientDto: IClientProfileDto = {
+        id: updatedClient.id,
+        userId: updatedClient.userId,
+        phoneNumber: updatedClient.phoneNumber || undefined,
+        city: updatedClient.city || undefined,
+        country: updatedClient.country || undefined,
+        gender: updatedClient.gender || undefined,
+        dateOfBirth: updatedClient.dateOfBirth || undefined,
+        socialLinks: updatedClient.socialLink.map((link) => ({
+          id: link.id,
+          platform: link.platform,
+          url: link.url,
+        })),
+      };
+
+      return ClientMapper.persistanceTodomain(updatedClientDto);
+    } catch (error) {
+      console.error(error);
+      throw new ApiError(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        "Failed to update client profile"
+      );
+    }
+  }
+}

--- a/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
@@ -5,11 +5,10 @@ import { injectable } from "tsyringe";
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import { StatusCodes } from "http-status-codes";
 import ClientMapper from "../../mappers/ClientMapper";
-import { IClientProfileDto } from "../../domain/interfaces/dtos/IClientProfileDto";
 
 @injectable()
 export class ClientRepository implements IClientRepository {
-  async getClientProfileById(id: string): Promise<Client | null> {
+  async getClientProfileById(id: string): Promise<Client> {
     const clientProfile = await prismaClient.client.findUnique({
       where: { id },
       include: { socialLink: true },
@@ -19,22 +18,7 @@ export class ClientRepository implements IClientRepository {
       throw new ApiError(StatusCodes.NOT_FOUND, "The client doesn't exist");
     }
 
-    // Adapt prisma object to dto
-    const clientProfileDto: IClientProfileDto = {
-      id: clientProfile.id, //check this id here an in ClientMapper
-      userId: clientProfile.userId,
-      phoneNumber: clientProfile.phoneNumber || undefined,
-      country: clientProfile.country || undefined,
-      city: clientProfile.city || undefined,
-      gender: clientProfile.gender || undefined,
-      dateOfBirth: clientProfile.dateOfBirth || undefined,
-      socialLinks: clientProfile.socialLink.map((link) => ({
-        id: link.id,
-        platform: link.platform,
-        url: link.url,
-      })),
-    };
-
+    const clientProfileDto = ClientMapper.persistanceToDto(clientProfile);
     return ClientMapper.persistanceTodomain(clientProfileDto);
   }
 
@@ -51,7 +35,7 @@ export class ClientRepository implements IClientRepository {
           gender: clientDto.gender ?? "",
           dateOfBirth: clientDto.dateOfBirth ?? null,
           socialLink: {
-            deleteMany: {}, // this replace previous links each time
+            deleteMany: {},
             create:
               clientDto.socialLinks?.map((link) => ({
                 platform: link.platform,
@@ -64,22 +48,7 @@ export class ClientRepository implements IClientRepository {
         },
       });
 
-      // Map prisma to clientprofiledto
-      const updatedClientDto: IClientProfileDto = {
-        id: updatedClient.id,
-        userId: updatedClient.userId,
-        phoneNumber: updatedClient.phoneNumber || undefined,
-        city: updatedClient.city || undefined,
-        country: updatedClient.country || undefined,
-        gender: updatedClient.gender || undefined,
-        dateOfBirth: updatedClient.dateOfBirth || undefined,
-        socialLinks: updatedClient.socialLink.map((link) => ({
-          id: link.id,
-          platform: link.platform,
-          url: link.url,
-        })),
-      };
-
+      const updatedClientDto = ClientMapper.persistanceToDto(updatedClient);
       return ClientMapper.persistanceTodomain(updatedClientDto);
     } catch (error) {
       console.error(error);

--- a/src/contexts/CoreContext/mappers/ClientMapper.ts
+++ b/src/contexts/CoreContext/mappers/ClientMapper.ts
@@ -1,0 +1,73 @@
+import { Client } from "../domain/aggregates/Client";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { UserId } from "../domain/valueObjects/UserId";
+import { PhoneNumber } from "../domain/valueObjects/PhoneNumber";
+import { City } from "../domain/valueObjects/City";
+import { Country } from "../domain/valueObjects/Country";
+import { Gender } from "../domain/valueObjects/Gender";
+import { DateOfBirth } from "../domain/valueObjects/DateOfBirth";
+import { SocialLinks } from "../domain/OneToMany/SocialLinks";
+import { SocialLinkMapper } from "./SocialLinksMapper";
+import { IClientProfileDto } from "../domain/interfaces/dtos/IClientProfileDto";
+
+export default class ClientMapper {
+  static persistanceTodomain(clientDto: IClientProfileDto): Client {
+    try {
+      return Client.create(
+        {
+          userId: UserId.create(new UniqueEntityID(clientDto.userId)),
+          phoneNumber: clientDto.phoneNumber
+            ? PhoneNumber.create(clientDto.phoneNumber)
+            : undefined,
+
+          city: clientDto.city ? City.create(clientDto.city) : undefined,
+
+          country: clientDto.country
+            ? Country.create(clientDto.country)
+            : undefined,
+
+          gender: clientDto.gender
+            ? Gender.create(clientDto.gender)
+            : undefined,
+
+          dateOfBirth: clientDto.dateOfBirth
+            ? DateOfBirth.create(
+                typeof clientDto.dateOfBirth === "string"
+                  ? new Date(clientDto.dateOfBirth)
+                  : clientDto.dateOfBirth
+              )
+            : undefined,
+
+          socialLinks: clientDto.socialLinks
+            ? SocialLinks.create(
+                new SocialLinkMapper().mapArrayPersistanceToDomain(
+                  clientDto.socialLinks
+                )
+              )
+            : undefined,
+        },
+        new UniqueEntityID(clientDto.id)
+      );
+    } catch (e) {
+      console.log(e);
+      throw new Error("cant mapp persistance to domain in ClientMapper");
+    }
+  }
+
+  static domainToGetClientDto(client: Client): IClientProfileDto {
+    return {
+      userId: client.userId.toString(),
+      id: client.id.toString(),
+      phoneNumber: client.phoneNumber?.value,
+      country: client.country?.value,
+      city: client.city?.value,
+      gender: client.gender?.value,
+      dateOfBirth: client.dateOfBirth?.value,
+      socialLinks: client.socialLinks
+        ? new SocialLinkMapper().mapArrayDomainToDto(
+            client.socialLinks.currentItems
+          )
+        : [],
+    };
+  }
+}

--- a/src/contexts/CoreContext/mappers/ClientMapper.ts
+++ b/src/contexts/CoreContext/mappers/ClientMapper.ts
@@ -9,6 +9,11 @@ import { DateOfBirth } from "../domain/valueObjects/DateOfBirth";
 import { SocialLinks } from "../domain/OneToMany/SocialLinks";
 import { SocialLinkMapper } from "./SocialLinksMapper";
 import { IClientProfileDto } from "../domain/interfaces/dtos/IClientProfileDto";
+import { Prisma } from "@/generated/prisma";
+
+type ClientWithSocialLinks = Prisma.ClientGetPayload<{
+  include: { socialLink: true };
+}>;
 
 export default class ClientMapper {
   static persistanceTodomain(clientDto: IClientProfileDto): Client {
@@ -68,6 +73,25 @@ export default class ClientMapper {
             client.socialLinks.currentItems
           )
         : [],
+    };
+  }
+
+  static persistanceToDto(
+    prismaClient: ClientWithSocialLinks
+  ): IClientProfileDto {
+    return {
+      id: prismaClient.id,
+      userId: prismaClient.userId,
+      phoneNumber: prismaClient.phoneNumber || undefined,
+      country: prismaClient.country || undefined,
+      city: prismaClient.city || undefined,
+      gender: prismaClient.gender || undefined,
+      dateOfBirth: prismaClient.dateOfBirth || undefined,
+      socialLinks: prismaClient.socialLink.map((link) => ({
+        id: link.id,
+        platform: link.platform,
+        url: link.url,
+      })),
     };
   }
 }

--- a/src/contexts/CoreContext/mappers/SocialLinksMapper.ts
+++ b/src/contexts/CoreContext/mappers/SocialLinksMapper.ts
@@ -1,0 +1,35 @@
+import { SocialLink as PrismaSocialLink } from "@/generated/prisma";
+import { ArrayToArrayMapper } from "./ArrayToArrayMapper";
+import { SocialLink } from "../domain/valueObjects/SocialLink";
+import ISocialLinkDto from "../domain/interfaces/dtos/ISocialLinkDto";
+
+export class SocialLinkMapper extends ArrayToArrayMapper<
+  SocialLink,
+  PrismaSocialLink
+> {
+  mapPersistanceToDomain(origin: ISocialLinkDto): SocialLink {
+    return SocialLink.create({
+      platform: origin.platform,
+      url: origin.url,
+    });
+  }
+
+  mapArrayPersistanceToDomain(origins: ISocialLinkDto[]): SocialLink[] {
+    return origins.map((origin) => this.mapPersistanceToDomain(origin));
+  }
+
+  mapDomainToPersistance(origin: SocialLink): PrismaSocialLink {
+    console.log(origin);
+    throw new Error("Method not implemented.");
+  }
+
+  mapDomainToDto(domain: SocialLink): ISocialLinkDto {
+    return {
+      platform: domain.props.platform,
+      url: domain.props.url,
+    };
+  }
+  mapArrayDomainToDto(items: SocialLink[]): ISocialLinkDto[] {
+    return items.map((item) => this.mapDomainToDto(item));
+  }
+}

--- a/src/contexts/CoreContext/presentation/http/controllers/ClientController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/ClientController.ts
@@ -1,0 +1,79 @@
+import { IClientController } from "@/contexts/CoreContext/domain/interfaces/controllers/IClientController";
+import { IClientService } from "@/contexts/CoreContext/domain/interfaces/services/IClientService";
+import { inject, injectable } from "tsyringe";
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import { SuccessResponseEntity } from "@/contexts/Shared/domain/entity/SuccessResponseEntity";
+import { ResponseService } from "@/contexts/Shared/application/services/ResponseService";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import ClientMapper from "@/contexts/CoreContext/mappers/ClientMapper";
+import { IClientProfileDto } from "@/contexts/CoreContext/domain/interfaces/dtos/IClientProfileDto";
+import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
+
+@injectable()
+export class ClientController implements IClientController {
+  constructor(
+    @inject("IClientService") private readonly clientService: IClientService
+  ) {}
+
+  get = async (req: Request, res: Response) => {
+    try {
+      const id: string = req.params.id;
+      const client = await this.clientService.get(id);
+      if (client !== null) {
+        const clientDto = ClientMapper.domainToGetClientDto(client);
+        const response = new SuccessResponseEntity(
+          clientDto,
+          StatusCodes.OK,
+          "Client retrieved successfully"
+        );
+        ResponseService.send(res, response);
+      } else {
+        throw new ApiError(StatusCodes.BAD_REQUEST, "Client not found");
+      }
+    } catch (error) {
+      if (error as ApiError) {
+        throw error;
+      } else {
+        throw new ApiError(StatusCodes.INTERNAL_SERVER_ERROR, "server error");
+      }
+    }
+  };
+
+  update = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const clientId: string = req.params.id;
+      const updateData: IClientProfileDto = req.body;
+
+      if (!clientId) {
+        throw new ApiError(
+          StatusCodes.UNAUTHORIZED,
+          "Client not authenticated"
+        );
+      }
+
+      const client: Client = ClientMapper.persistanceTodomain(updateData);
+
+      if (!client) {
+        throw new ApiError(
+          StatusCodes.NOT_FOUND,
+          `Client with ID ${clientId} not found`
+        );
+      }
+
+      const updatedClient = await this.clientService.update(clientId, client);
+      const response = new SuccessResponseEntity(
+        ClientMapper.domainToGetClientDto(updatedClient),
+        StatusCodes.OK,
+        "Client updated successfully"
+      );
+      ResponseService.send(res, response);
+    } catch (error) {
+      console.error(error);
+      throw new ApiError(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        "Failed to update user"
+      );
+    }
+  };
+}

--- a/src/contexts/CoreContext/presentation/http/routes/ClientRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/ClientRoutes.ts
@@ -1,0 +1,116 @@
+import { IClientController } from "@/contexts/CoreContext/domain/interfaces/controllers/IClientController";
+//import { verifyToken } from "@/contexts/Shared/infrastructure/middlewares/TokenVerifierMiddleware";
+import { Router } from "express";
+import { container } from "tsyringe";
+
+const controller = container.resolve<IClientController>("IClientController");
+
+const router = Router();
+
+/**
+ * @openapi
+ * /clients/{id}:
+ *  get:
+ *     summary: Get a client by ID
+ *     tags:
+ *       - Client
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID of the client
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Client retrieved successfully
+ *       400:
+ *         description: Client not found
+ *       500:
+ *         description: Server error
+ */
+router.get("/:id", controller.get);
+
+/**
+ * @openapi
+ * /clients/{id}:
+ *  put:
+ *     summary: Update client by ID
+ *     tags:
+ *       - Client
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID of the client
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ClientProfileDto'
+ *     responses:
+ *       200:
+ *         description: Client updated successfully
+ *       400:
+ *         description: Invalid input or client not found
+ *       500:
+ *         description: Server error
+ */
+router.put("/:id", controller.update);
+
+export default router;
+
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     SocialLinkDto:
+ *       type: object
+ *       properties:
+ *         platform:
+ *           type: string
+ *           description: Name of the social media platform (e.g., "YOUTUBE")
+ *           example: "LINKEDIN"
+ *         url:
+ *           type: string
+ *           description: URL to the user's profile, must be a valid URL
+ *           example: "https://linkedin.com/in/example"
+ *       required:
+ *         - platform
+ *         - url
+ *
+ *     ClientProfileDto:
+ *       type: object
+ *       properties:
+ *         phoneNumber:
+ *           type: string
+ *           description: Phone number in international format, e.g., +54 911 1234-5678
+ *           example: "+54 911 1234-5678"
+ *         city:
+ *           type: string
+ *           description: City of residence, free text
+ *           example: "Buenos Aires"
+ *         country:
+ *           type: string
+ *           description: Country of residence, free text
+ *           example: "Argentina"
+ *         gender:
+ *           type: string
+ *           description: Gender identity, e.g., "male", "female", "other"
+ *           example: "male"
+ *         dateOfBirth:
+ *           type: string
+ *           format: date
+ *           description: Date of birth in YYYY-MM-DD format
+ *           example: "1995-07-17"
+ *         socialLinks:
+ *           type: array
+ *           description: List of the client's social media profiles
+ *           items:
+ *             $ref: '#/components/schemas/SocialLinkDto'
+ *       required:
+ *         - userId
+ */

--- a/src/di-container.ts
+++ b/src/di-container.ts
@@ -99,6 +99,14 @@ import { IExternarlAuthService } from "./contexts/CoreContext/domain/interfaces/
 import { KeycloakService } from "./contexts/CoreContext/infrastructure/keycloak/keycloakService";
 import { SyncUserUseCase } from "./contexts/CoreContext/application/useCases/auth/SyncUserUseCase";
 import { IAuthService } from "./contexts/CoreContext/domain/interfaces/services/IAuthService";
+import { IClientService } from "./contexts/CoreContext/domain/interfaces/services/IClientService";
+import ClientService from "./contexts/CoreContext/application/services/ClientService";
+import { IClientController } from "./contexts/CoreContext/domain/interfaces/controllers/IClientController";
+import { ClientController } from "./contexts/CoreContext/presentation/http/controllers/ClientController";
+import { GetClientUseCase } from "./contexts/CoreContext/application/useCases/client/GetClientUseCase";
+import { UpdateClientUseCase } from "./contexts/CoreContext/application/useCases/client/UpdateClientUseCase";
+import { ClientRepository } from "./contexts/CoreContext/infrastructure/persistence/ClientRepository";
+import { IClientRepository } from "./contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
 
 //User
 container.registerSingleton<IUserRepository>("IUserRepository", UserRepository);
@@ -378,4 +386,21 @@ container.registerSingleton<IExternarlAuthService>(
   KeycloakService
 );
 
+container.registerSingleton<IClientService>("IClientService", ClientService);
+container.registerSingleton<IClientController>(
+  "IClientController",
+  ClientController
+);
+container.registerSingleton<GetClientUseCase>(
+  "GetClientUseCase",
+  GetClientUseCase
+);
+container.registerSingleton<UpdateClientUseCase>(
+  "UpdateClientUseCase",
+  UpdateClientUseCase
+);
+container.registerSingleton<IClientRepository>(
+  "IClientRepository",
+  ClientRepository
+);
 export { container };

--- a/tests/contexts/coreContext/application/services/ClientService.spec.ts
+++ b/tests/contexts/coreContext/application/services/ClientService.spec.ts
@@ -1,0 +1,81 @@
+import "reflect-metadata";
+import ClientService from "@/contexts/CoreContext/application/services/ClientService";
+import { GetClientUseCase } from "@/contexts/CoreContext/application/useCases/client/GetClientUseCase";
+import { UpdateClientUseCase } from "@/contexts/CoreContext/application/useCases/client/UpdateClientUseCase";
+import { ClientMother } from "../../useCases/client/ClientMotherMock";
+
+const mockGetClientUseCase = {
+  execute: jest.fn(),
+};
+
+const mockUpdateClientUseCase = {
+  execute: jest.fn(),
+};
+
+describe("ClientService", () => {
+  let service: ClientService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ClientService(
+      mockGetClientUseCase as unknown as GetClientUseCase,
+      mockUpdateClientUseCase as unknown as UpdateClientUseCase
+    );
+  });
+
+  describe("get", () => {
+    it("should return client when getClientsUseCase.execute resolves", async () => {
+      const mockClient = ClientMother.createValidClient();
+      mockGetClientUseCase.execute.mockResolvedValue(mockClient);
+
+      const result = await service.get(mockClient.clientId.toString());
+
+      expect(mockGetClientUseCase.execute).toHaveBeenCalledWith(
+        mockClient.clientId.toString()
+      );
+      expect(result).toBe(mockClient);
+    });
+
+    it("should return null when getClientsUseCase.execute resolves null", async () => {
+      mockGetClientUseCase.execute.mockResolvedValue(null);
+
+      const result = await service.get("non-existent-id");
+
+      expect(mockGetClientUseCase.execute).toHaveBeenCalledWith(
+        "non-existent-id"
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("update", () => {
+    it("should call updateClientUseCase.execute and return updated client", async () => {
+      const mockClient = ClientMother.createValidClient();
+
+      mockUpdateClientUseCase.execute.mockResolvedValue(mockClient);
+
+      const result = await service.update(
+        mockClient.clientId.toString(),
+        mockClient
+      );
+
+      expect(mockUpdateClientUseCase.execute).toHaveBeenCalledWith({
+        clientId: mockClient.clientId.toString(),
+        clientData: mockClient,
+      });
+      expect(result).toBe(mockClient);
+    });
+
+    it("should throw if updateClientUseCase.execute throws", async () => {
+      const mockClient = ClientMother.createValidClient();
+
+      mockUpdateClientUseCase.execute.mockRejectedValue(
+        new Error("Update failed")
+      );
+
+      await expect(
+        service.update(mockClient.clientId.toString(), mockClient)
+      ).rejects.toThrow("Update failed");
+    });
+  });
+});

--- a/tests/contexts/coreContext/domain/valueObjects/SocialLink.spec.ts
+++ b/tests/contexts/coreContext/domain/valueObjects/SocialLink.spec.ts
@@ -6,18 +6,18 @@ describe("SocialLink", () => {
   describe("create", () => {
     it("should create a valid social link", () => {
       const link = SocialLink.create({
-        platform: "linkedin",
+        platform: "LINKEDIN",
         url: "https://linkedin.com/in/test",
       });
-      expect(link.platform).toBe("linkedin");
+      expect(link.platform).toBe("LINKEDIN");
       expect(link.url).toBe("https://linkedin.com/in/test");
     });
 
     it("should throw if url is missing", () => {
-      expect(() => SocialLink.create({ platform: "youtube", url: "" })).toThrow(
+      expect(() => SocialLink.create({ platform: "YOUTUBE", url: "" })).toThrow(
         ApiError
       );
-      expect(() => SocialLink.create({ platform: "youtube", url: "" })).toThrow(
+      expect(() => SocialLink.create({ platform: "YOUTUBE", url: "" })).toThrow(
         "SocialLink is required"
       );
     });
@@ -44,7 +44,7 @@ describe("SocialLink", () => {
   describe("structure", () => {
     it("should extend ValueObject", () => {
       const link = SocialLink.create({
-        platform: "instagram",
+        platform: "INSTAGRAM",
         url: "https://instagram.com/user",
       });
       expect(link).toBeInstanceOf(ValueObject);
@@ -52,10 +52,10 @@ describe("SocialLink", () => {
 
     it("should expose platform and url getters", () => {
       const link = SocialLink.create({
-        platform: "youtube",
+        platform: "YOUTUBE",
         url: "https://youtube.com/user",
       });
-      expect(link.platform).toBe("youtube");
+      expect(link.platform).toBe("YOUTUBE");
       expect(link.url).toBe("https://youtube.com/user");
     });
   });

--- a/tests/contexts/coreContext/presentation/ClientController.spec.ts
+++ b/tests/contexts/coreContext/presentation/ClientController.spec.ts
@@ -1,0 +1,89 @@
+import "reflect-metadata";
+import { IClientService } from "@/contexts/CoreContext/domain/interfaces/services/IClientService";
+import { Request, Response } from "express";
+import ClientMapper from "@/contexts/CoreContext/mappers/ClientMapper";
+import { IClientProfileDto } from "@/contexts/CoreContext/domain/interfaces/dtos/IClientProfileDto";
+import { ClientController } from "@/contexts/CoreContext/presentation/http/controllers/ClientController";
+import { ClientMother } from "../useCases/client/ClientMotherMock";
+
+const mockClientService: jest.Mocked<IClientService> = {
+  get: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockResponse = () => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("ClientController - update", () => {
+  let controller: ClientController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new ClientController(mockClientService);
+  });
+
+  it("should update the client and return success response", async () => {
+    const mockClient = ClientMother.createValidClient();
+    const clientDto: IClientProfileDto =
+      ClientMapper.domainToGetClientDto(mockClient);
+
+    const req = {
+      params: { id: mockClient.clientId.toString() },
+      body: clientDto,
+    } as unknown as Request;
+
+    const res = mockResponse();
+
+    mockClientService.update.mockResolvedValue(mockClient);
+
+    await controller.update(req, res);
+
+    expect(mockClientService.update).toHaveBeenCalledWith(
+      mockClient.clientId.toString(),
+      expect.anything()
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: clientDto,
+        message: "Client updated successfully",
+      })
+    );
+  });
+
+  it("should throw UNAUTHORIZED if clientId is missing", async () => {
+    const req = {
+      params: {},
+      body: {} as IClientProfileDto,
+    } as unknown as Request;
+
+    const res = mockResponse();
+
+    await expect(controller.update(req, res)).rejects.toThrow(
+      "Failed to update user"
+    );
+  });
+
+  it("should return 500 if update fails", async () => {
+    const mockClient = ClientMother.createValidClient();
+    const clientDto: IClientProfileDto =
+      ClientMapper.domainToGetClientDto(mockClient);
+
+    const req = {
+      params: { id: mockClient.clientId.toString() },
+      body: clientDto,
+    } as unknown as Request;
+
+    const res = mockResponse();
+
+    mockClientService.update.mockRejectedValue(new Error("Update failed"));
+
+    await expect(controller.update(req, res)).rejects.toThrow(
+      "Failed to update user"
+    );
+  });
+});

--- a/tests/contexts/coreContext/useCases/client/ClientMotherMock.ts
+++ b/tests/contexts/coreContext/useCases/client/ClientMotherMock.ts
@@ -1,0 +1,46 @@
+import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
+import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
+import { UserId } from "@/contexts/CoreContext/domain/valueObjects/UserId";
+import { PhoneNumber } from "@/contexts/CoreContext/domain/valueObjects/PhoneNumber";
+import { Country } from "@/contexts/CoreContext/domain/valueObjects/Country";
+import { City } from "@/contexts/CoreContext/domain/valueObjects/City";
+import { Gender } from "@/contexts/CoreContext/domain/valueObjects/Gender";
+import { DateOfBirth } from "@/contexts/CoreContext/domain/valueObjects/DateOfBirth";
+import { SocialLinks } from "@/contexts/CoreContext/domain/OneToMany/SocialLinks";
+import { SocialLink } from "@/contexts/CoreContext/domain/valueObjects/SocialLink";
+
+export class ClientMother {
+  static createValidClient(): Client {
+    const userId = UserId.create(
+      new UniqueEntityID("e3e58457-f4f2-41a1-9cf8-bdd67103e912")
+    );
+    const phoneNumber = PhoneNumber.create("+54 911 1234-5678");
+    const country = Country.create("Argentina");
+    const city = City.create("Buenos Aires");
+    const gender = Gender.create("male");
+    const dateOfBirth = DateOfBirth.create(new Date("1995-07-17"));
+    const socialLinks = SocialLinks.create([
+      SocialLink.create({
+        platform: "LINKEDIN",
+        url: "https://linkedin.com/in/example",
+      }),
+      SocialLink.create({
+        platform: "YOUTUBE",
+        url: "https://youtube.com/in/example",
+      }),
+    ]);
+
+    return Client.create(
+      {
+        userId,
+        phoneNumber,
+        country,
+        city,
+        gender,
+        dateOfBirth,
+        socialLinks,
+      },
+      new UniqueEntityID("46263e55-d602-4243-aea7-23db886bf860")
+    );
+  }
+}

--- a/tests/contexts/coreContext/useCases/client/ClientMotherMock.ts
+++ b/tests/contexts/coreContext/useCases/client/ClientMotherMock.ts
@@ -9,8 +9,8 @@ import { DateOfBirth } from "@/contexts/CoreContext/domain/valueObjects/DateOfBi
 import { SocialLinks } from "@/contexts/CoreContext/domain/OneToMany/SocialLinks";
 import { SocialLink } from "@/contexts/CoreContext/domain/valueObjects/SocialLink";
 
-export class ClientMother {
-  static createValidClient(): Client {
+export const ClientMother = {
+  createValidClient(): Client {
     const userId = UserId.create(
       new UniqueEntityID("e3e58457-f4f2-41a1-9cf8-bdd67103e912")
     );
@@ -42,5 +42,5 @@ export class ClientMother {
       },
       new UniqueEntityID("46263e55-d602-4243-aea7-23db886bf860")
     );
-  }
-}
+  },
+};

--- a/tests/contexts/coreContext/useCases/client/GetClientUseCase.spec.ts
+++ b/tests/contexts/coreContext/useCases/client/GetClientUseCase.spec.ts
@@ -1,0 +1,52 @@
+import "reflect-metadata";
+import { GetClientUseCase } from "@/contexts/CoreContext/application/useCases/client/GetClientUseCase";
+import { IClientRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { ClientMother } from "./ClientMotherMock";
+
+// Create a mocked version of IClientRepository
+const mockClientRepository: jest.Mocked<IClientRepository> = {
+  getClientProfileById: jest.fn(),
+  updateClientProfile: jest.fn(),
+};
+
+describe("GetClientUseCase", () => {
+  let useCase: GetClientUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCase = new GetClientUseCase(mockClientRepository);
+  });
+
+  it("should return the client if it exists", async () => {
+    const mockClient = ClientMother.createValidClient();
+    mockClientRepository.getClientProfileById.mockResolvedValue(mockClient);
+
+    const result = await useCase.execute(mockClient.clientId.toString());
+
+    expect(result).toBe(mockClient);
+    expect(mockClientRepository.getClientProfileById).toHaveBeenCalledWith(
+      mockClient.clientId.toString()
+    );
+  });
+
+  it("should throw an ApiError with NOT_FOUND if the client does not exist", async () => {
+    mockClientRepository.getClientProfileById.mockResolvedValue(null);
+
+    await expect(useCase.execute("non-existent-id")).rejects.toThrow(ApiError);
+    await expect(useCase.execute("non-existent-id")).rejects.toThrow(
+      "Client not found."
+    );
+  });
+
+  it("should throw an ApiError with INTERNAL_SERVER_ERROR if an unexpected error occurs", async () => {
+    mockClientRepository.getClientProfileById.mockRejectedValue(
+      new Error("DB failure")
+    );
+
+    await expect(useCase.execute("some-id")).rejects.toThrow(ApiError);
+    await expect(useCase.execute("some-id")).rejects.toThrow(
+      "server error in get client use case"
+    );
+  });
+});

--- a/tests/contexts/coreContext/useCases/client/GetClientUseCase.spec.ts
+++ b/tests/contexts/coreContext/useCases/client/GetClientUseCase.spec.ts
@@ -29,14 +29,15 @@ describe("GetClientUseCase", () => {
       mockClient.clientId.toString()
     );
   });
-
   it("should throw an ApiError with NOT_FOUND if the client does not exist", async () => {
-    mockClientRepository.getClientProfileById.mockResolvedValue(null);
-
-    await expect(useCase.execute("non-existent-id")).rejects.toThrow(ApiError);
-    await expect(useCase.execute("non-existent-id")).rejects.toThrow(
-      "Client not found."
+    mockClientRepository.getClientProfileById.mockRejectedValue(
+      new ApiError(404, "Client not found.")
     );
+
+    const result = useCase.execute("non-existent-id");
+
+    await expect(result).rejects.toThrow(ApiError);
+    await expect(result).rejects.toThrow("Client not found.");
   });
 
   it("should throw an ApiError with INTERNAL_SERVER_ERROR if an unexpected error occurs", async () => {

--- a/tests/contexts/coreContext/useCases/client/UpdateClientUseCase.spec.ts
+++ b/tests/contexts/coreContext/useCases/client/UpdateClientUseCase.spec.ts
@@ -3,6 +3,7 @@ import { UpdateClientUseCase } from "@/contexts/CoreContext/application/useCases
 import { IClientRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import { ClientMother } from "./ClientMotherMock";
+import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
 
 describe("UpdateClientUseCase", () => {
   const mockClientRepository: jest.Mocked<IClientRepository> = {
@@ -40,7 +41,9 @@ describe("UpdateClientUseCase", () => {
   });
 
   it("should throw if the client does not exist", async () => {
-    mockClientRepository.getClientProfileById.mockResolvedValue(null);
+    mockClientRepository.getClientProfileById.mockRejectedValue(
+      new ApiError(404, "Client not found")
+    );
 
     await expect(
       useCase.execute({
@@ -49,12 +52,13 @@ describe("UpdateClientUseCase", () => {
       })
     ).rejects.toThrow("Client not found");
   });
-
   it("should throw ApiError if update fails", async () => {
     const existingClient = ClientMother.createValidClient();
 
     mockClientRepository.getClientProfileById.mockResolvedValue(existingClient);
-    mockClientRepository.updateClientProfile.mockResolvedValue(null as any);
+    mockClientRepository.updateClientProfile.mockResolvedValue(
+      null as unknown as Client
+    );
     await expect(
       useCase.execute({
         clientId: existingClient.clientId.toString(),

--- a/tests/contexts/coreContext/useCases/client/UpdateClientUseCase.spec.ts
+++ b/tests/contexts/coreContext/useCases/client/UpdateClientUseCase.spec.ts
@@ -1,0 +1,72 @@
+import "reflect-metadata";
+import { UpdateClientUseCase } from "@/contexts/CoreContext/application/useCases/client/UpdateClientUseCase";
+import { IClientRepository } from "@/contexts/CoreContext/domain/interfaces/repositories/IClientRepository";
+import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
+import { ClientMother } from "./ClientMotherMock";
+
+describe("UpdateClientUseCase", () => {
+  const mockClientRepository: jest.Mocked<IClientRepository> = {
+    getClientProfileById: jest.fn(),
+    updateClientProfile: jest.fn(),
+  };
+
+  let useCase: UpdateClientUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCase = new UpdateClientUseCase(mockClientRepository);
+  });
+
+  it("should update the client successfully", async () => {
+    const existingClient = ClientMother.createValidClient();
+    const updatedClient = ClientMother.createValidClient();
+
+    mockClientRepository.getClientProfileById.mockResolvedValue(existingClient);
+    mockClientRepository.updateClientProfile.mockResolvedValue(updatedClient);
+
+    const result = await useCase.execute({
+      clientId: existingClient.clientId.toString(),
+      clientData: updatedClient,
+    });
+
+    expect(mockClientRepository.getClientProfileById).toHaveBeenCalledWith(
+      existingClient.clientId.toString()
+    );
+    expect(mockClientRepository.updateClientProfile).toHaveBeenCalledWith(
+      existingClient.clientId.toString(),
+      expect.anything()
+    );
+    expect(result).toBe(updatedClient);
+  });
+
+  it("should throw if the client does not exist", async () => {
+    mockClientRepository.getClientProfileById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute({
+        clientId: "non-existent-id",
+        clientData: ClientMother.createValidClient(),
+      })
+    ).rejects.toThrow("Client not found");
+  });
+
+  it("should throw ApiError if update fails", async () => {
+    const existingClient = ClientMother.createValidClient();
+
+    mockClientRepository.getClientProfileById.mockResolvedValue(existingClient);
+    mockClientRepository.updateClientProfile.mockResolvedValue(null as any);
+    await expect(
+      useCase.execute({
+        clientId: existingClient.clientId.toString(),
+        clientData: existingClient,
+      })
+    ).rejects.toThrow(ApiError);
+
+    await expect(
+      useCase.execute({
+        clientId: existingClient.clientId.toString(),
+        clientData: existingClient,
+      })
+    ).rejects.toThrow("Error while updating client");
+  });
+});


### PR DESCRIPTION
## Description

In this PR was implemented the GET and PUT methods for the `Client`. Following the convention we have to map to dtos in order to obtain data of DB or to push it.

## Main Changes
- ClientRoutes implemented to `/clients/clientId` to the methods GET and PUT
- Use of Dtos to interact with DB and avoid the dependency on Prisma
- Unit applied in: controller, service, usecases.

<img width="1057" height="550" alt="Screenshot 2025-07-17 114331" src="https://github.com/user-attachments/assets/63cf2df2-1835-497f-8281-1b60ad8ed869" />
<img width="1075" height="597" alt="Screenshot 2025-07-17 114310" src="https://github.com/user-attachments/assets/d215d945-a589-4495-8563-1ddf5951ba10" />
<img width="1331" height="177" alt="Screenshot 2025-07-17 114124" src="https://github.com/user-attachments/assets/518c7bd2-4883-42bb-8dbb-7167327a2f69" />


## Reviewers

@LucasMezzaJalaUniversity
@JoseCaJala
@cclaurevju
@ArielMonroy392
@MauricioLSalles
@ElamCanoJala
@AndreCarpio
@DanielRios491
@eduSpinouza
