### PR TITLE
Refactor User PATCH and migration of about from Freelancer to User

### DIFF
--- a/prisma/migrations/20250721191315_move_about_to_user/migration.sql
+++ b/prisma/migrations/20250721191315_move_about_to_user/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `about` on the `Freelancer` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Freelancer" DROP COLUMN "about";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "about" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,7 @@ model User {
   profilePicture     String?
   freelancerProfile  Freelancer? @relation("UserFreelancer") 
   clientProfile      Client?     @relation("UserClient")
+  about              String      @default("")
 
   proposals          Proposal[]
   requests           Request[]   
@@ -98,7 +99,6 @@ model Freelancer {
   id      String @id @default(uuid())
   userId  String @unique 
   user    User   @relation("UserFreelancer", fields: [userId], references: [id] , onDelete: Cascade)
-  about          String          @default("")
   skills         Skill[]
   languages      Language[]
   education      Education[]

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -18,6 +18,12 @@ const swaggerOptions: SwaggerOptions = {
       {
         name: "User",
       },
+      {
+        name: "Client",
+      },
+      {
+        name: "Freelancer",
+      },
     ],
     servers: [
       {

--- a/src/contexts/CoreContext/application/services/UserService.ts
+++ b/src/contexts/CoreContext/application/services/UserService.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "tsyringe";
-import { User } from "../../domain/aggregates/User";
+import { User, UserProps } from "../../domain/aggregates/User";
 import { IUserService } from "../../domain/interfaces/services/IUserService";
 import { CreateUserFreelancerProfileUseCase } from "../useCases/CreateUserFreelancerProfileUseCase";
 import { CreateUserUseCase } from "../useCases/CreateUserUseCase";
@@ -36,7 +36,10 @@ export class UserService implements IUserService {
   getAll(): Promise<User[]> {
     throw new Error("Method not implemented.");
   }
-  update(id: string, userData: User): Promise<User> {
+  update(id: string, userData: Partial<UserProps>): Promise<User> {
+    return this.updateUserProfile(id, userData);
+  }
+  updateUserProfile(id: string, userData: Partial<UserProps>): Promise<User> {
     return this.updateUserUseCase.execute({ userId: id, userData });
   }
   async create(user: User): Promise<User> {

--- a/src/contexts/CoreContext/application/useCases/UpdateUserUseCase.ts
+++ b/src/contexts/CoreContext/application/useCases/UpdateUserUseCase.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "tsyringe";
-import { User } from "../../domain/aggregates/User";
+import { User, UserProps } from "../../domain/aggregates/User";
 import { IUserRepository } from "../../domain/interfaces/repositories/IUserRepository";
 import IUseCase from "@/contexts/LearningContext/domain/interfaces/IUseCase";
 
 @injectable()
 export class UpdateUserUseCase
-  implements IUseCase<{ userId: string; userData: User }, User>
+  implements IUseCase<{ userId: string; userData: Partial<UserProps> }, User>
 {
   constructor(
     @inject("IUserRepository")
@@ -17,13 +17,18 @@ export class UpdateUserUseCase
     userData,
   }: {
     userId: string;
-    userData: User;
+    userData: Partial<UserProps>;
   }): Promise<User> {
-    const user = await this.userRepository.getById(userId);
-    if (!user) throw new Error("User not found");
+    const existingUser = await this.userRepository.getById(userId);
+    if (!existingUser) {
+      throw new Error("User not found");
+    }
 
-    Object.assign(user, userData);
-    const updatedUser = await this.userRepository.update(userId, user);
+    const updatedUser = await this.userRepository.updateUserProfile(
+      userId,
+      userData
+    );
+
     if (!updatedUser) throw new Error("Failed to update user");
     return updatedUser;
   }

--- a/src/contexts/CoreContext/domain/aggregates/Freelancer.ts
+++ b/src/contexts/CoreContext/domain/aggregates/Freelancer.ts
@@ -1,5 +1,4 @@
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
-import { About } from "../valueObjects/About";
 import { UserId } from "../valueObjects/UserId";
 import { AggregateRoot } from "@/contexts/Shared/domain/AgregateRoot";
 import { Languages } from "../OneToMany/Languages";
@@ -10,7 +9,6 @@ import { Skills } from "../OneToMany/Skills";
 
 interface FreelancerProps {
   userId: UserId;
-  about: About;
   skills: Skills;
   languages: Languages;
   education: Educations;
@@ -26,10 +24,6 @@ export class Freelancer extends AggregateRoot<FreelancerProps> {
     props: FreelancerProps,
     id?: UniqueEntityID
   ): Freelancer {
-    if (!props.about) {
-      throw new Error("About is required.");
-    }
-
     return new Freelancer(props, id);
   }
 
@@ -39,10 +33,6 @@ export class Freelancer extends AggregateRoot<FreelancerProps> {
 
   get userId(): UserId {
     return this.props.userId;
-  }
-
-  get about(): About {
-    return this.props.about;
   }
 
   get skills(): Skills {

--- a/src/contexts/CoreContext/domain/aggregates/User.ts
+++ b/src/contexts/CoreContext/domain/aggregates/User.ts
@@ -16,6 +16,7 @@ export interface UserProps {
   freelancerId?: UniqueEntityID;
   createdAt: Date;
   profilePicture?: string;
+  about: string;
 }
 
 export class User extends AggregateRoot<UserProps> {
@@ -41,6 +42,10 @@ export class User extends AggregateRoot<UserProps> {
 
   get profilePicture() {
     return this.props.profilePicture;
+  }
+
+  get about() {
+    return this.props.about;
   }
 
   // Getters per profile
@@ -114,6 +119,9 @@ export class User extends AggregateRoot<UserProps> {
         freelancerId: profiles.freelancerProfile,
         createdAt: props.createdAt ?? new Date(),
         profilePicture: props.profilePicture ?? "",
+        about:
+          props.about ??
+          "Tell others a bit about your background, skills, and interests...",
       },
       id
     );

--- a/src/contexts/CoreContext/domain/interfaces/dao/FreelancerDao.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dao/FreelancerDao.ts
@@ -3,7 +3,6 @@ import { SkillLevel } from "../../entities/Skill";
 export type FreelancerDao = {
   userId: string;
   id: string;
-  about: string;
   skills: {
     name: string;
     id: string;

--- a/src/contexts/CoreContext/domain/interfaces/dao/UserDao.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dao/UserDao.ts
@@ -3,7 +3,6 @@ import { UserRole } from "@/generated/prisma";
 export type UserDao = {
   freelancerProfile: {
     id: string;
-    about: string;
     userId: string;
   } | null;
   clientProfile: {
@@ -16,4 +15,5 @@ export type UserDao = {
   profilePicture: string | null;
   roles: UserRole[];
   createdAt: Date;
+  about: string;
 };

--- a/src/contexts/CoreContext/domain/interfaces/dtos/ICreateUserDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/ICreateUserDto.ts
@@ -3,4 +3,5 @@ export interface ICreateUserDto {
   userName: string;
   userEmail: string;
   profilePicture: string;
+  about: string;
 }

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IFreelancerProfileDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IFreelancerProfileDto.ts
@@ -6,7 +6,6 @@ import { IGetCertificationDTO } from "./certifications/IGetCertificationDto";
 
 export interface IFreelancerProfileDto {
   id?: string;
-  about: string;
   skills?: ISkillDto[];
   languages?: ILanguageDto[];
   education?: IEducationDto[];

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IGetUserDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IGetUserDto.ts
@@ -9,4 +9,5 @@ export interface IGetUserDto {
   freelancerProfile: string | undefined;
   clientProfile: string | undefined;
   profilePicture: string | undefined;
+  about: string;
 }

--- a/src/contexts/CoreContext/domain/interfaces/dtos/IUserUpdateDto.ts
+++ b/src/contexts/CoreContext/domain/interfaces/dtos/IUserUpdateDto.ts
@@ -1,0 +1,5 @@
+export default interface IUserUpdateDto {
+  userName?: string;
+  profilePicture?: string;
+  about?: string;
+}

--- a/src/contexts/CoreContext/domain/interfaces/repositories/IUserRepository.ts
+++ b/src/contexts/CoreContext/domain/interfaces/repositories/IUserRepository.ts
@@ -1,7 +1,8 @@
 import { IRepository } from "@/contexts/Shared/domain/repository/IRepository";
-import { User } from "../../aggregates/User";
+import { User, UserProps } from "../../aggregates/User";
 
 export interface IUserRepository extends IRepository<User> {
   addFreelancerProfile(id: string): Promise<User>;
   getUserProfileById(id: string): Promise<User | null>;
+  updateUserProfile(id: string, user: Partial<UserProps>): Promise<User | null>;
 }

--- a/src/contexts/CoreContext/domain/interfaces/services/IUserService.ts
+++ b/src/contexts/CoreContext/domain/interfaces/services/IUserService.ts
@@ -1,7 +1,8 @@
 import { IService } from "@/contexts/Shared/domain/service/IService";
-import { User } from "../../aggregates/User";
+import { User, UserProps } from "../../aggregates/User";
 export interface IUserService extends IService<User> {
   delete(id: string): Promise<string | void>;
   addRole(role: string): Promise<void>;
   createFreelanceProfile(id: string): Promise<User>;
+  updateUserProfile(id: string, user: Partial<UserProps>): Promise<User | null>;
 }

--- a/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/ClientRepository.ts
@@ -17,7 +17,6 @@ export class ClientRepository implements IClientRepository {
     if (!clientProfile) {
       throw new ApiError(StatusCodes.NOT_FOUND, "The client doesn't exist");
     }
-
     const clientProfileDto = ClientMapper.persistanceToDto(clientProfile);
     return ClientMapper.persistanceTodomain(clientProfileDto);
   }

--- a/src/contexts/CoreContext/infrastructure/persistence/UserRepository.ts
+++ b/src/contexts/CoreContext/infrastructure/persistence/UserRepository.ts
@@ -1,11 +1,12 @@
 import prismaClient from "@/contexts/Shared/infrastructure/database/PrismaClient";
-import { User } from "../../domain/aggregates/User";
+import { User, UserProps } from "../../domain/aggregates/User";
 import { IUserRepository } from "../../domain/interfaces/repositories/IUserRepository";
 import UserMapper from "../../mappers/UserMapper";
 import { UserDao } from "../../domain/interfaces/dao/UserDao";
 import { injectable } from "tsyringe";
 import { ApiError } from "@/contexts/Shared/infrastructure/errors/ApiError";
 import { StatusCodes } from "http-status-codes";
+import IUserUpdateDto from "../../domain/interfaces/dtos/IUserUpdateDto";
 
 @injectable()
 export class UserRepository implements IUserRepository {
@@ -49,6 +50,9 @@ export class UserRepository implements IUserRepository {
   }
 
   delete(): Promise<string | void> {
+    throw new Error("Method not implemented.");
+  }
+  update(): Promise<User | void> {
     throw new Error("Method not implemented.");
   }
 
@@ -95,18 +99,27 @@ export class UserRepository implements IUserRepository {
     }
   }
 
-  async update(userId: string, userData: User): Promise<User> {
+  async updateUserProfile(
+    userId: string,
+    userData: Partial<UserProps>
+  ): Promise<User> {
+    const dataToUpdate: IUserUpdateDto = Object.fromEntries(
+      Object.entries({
+        userName: userData.userName ? userData.userName.value : undefined,
+        profilePicture: userData.profilePicture,
+        about: userData.about,
+      }).filter(([, value]) => value !== undefined && value !== "")
+    );
+
     const user = await prismaClient.user.update({
       where: { id: userId },
-      data: {
-        userName: userData.userName.value,
-        profilePicture: userData.profilePicture,
-      },
+      data: dataToUpdate,
       include: {
         freelancerProfile: true,
         clientProfile: true,
       },
     });
+
     return UserMapper.persistanceTodomain(user);
   }
 

--- a/src/contexts/CoreContext/mappers/ClientMapper.ts
+++ b/src/contexts/CoreContext/mappers/ClientMapper.ts
@@ -46,7 +46,9 @@ export default class ClientMapper {
           socialLinks: clientDto.socialLinks
             ? SocialLinks.create(
                 new SocialLinkMapper().mapArrayPersistanceToDomain(
-                  clientDto.socialLinks
+                  clientDto.socialLinks.filter(
+                    (link) => link.url?.trim() !== ""
+                  )
                 )
               )
             : undefined,

--- a/src/contexts/CoreContext/mappers/FreelancerMapper.ts
+++ b/src/contexts/CoreContext/mappers/FreelancerMapper.ts
@@ -1,7 +1,6 @@
 import { Freelancer } from "../domain/aggregates/Freelancer";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
 import { IFreelancerProfileDto } from "../domain/interfaces/dtos/IFreelancerProfileDto";
-import { About } from "../domain/valueObjects/About";
 import { UserId } from "../domain/valueObjects/UserId";
 import { Skills } from "../domain/OneToMany/Skills";
 import { Languages } from "../domain/OneToMany/Languages";
@@ -25,7 +24,6 @@ export default class FreelancerMapper {
   static domainToDto(freelancer: Freelancer): IFreelancerProfileDto {
     return {
       id: freelancer.id.toString(),
-      about: freelancer.about.value,
       certifications: freelancer.certifications.currentItems.map((cert) => {
         return new CertificationMapper().mapDomainToDto(cert);
       }),
@@ -57,7 +55,6 @@ export default class FreelancerMapper {
       {
         //create mappers from eities
         userId: UserId.create(new UniqueEntityID(prismaFreelancer.userId)),
-        about: About.create(prismaFreelancer.about),
         skills: Skills.create(
           new SkillMapper().mapArrayPersistanceToDomain(prismaFreelancer.skills)
         ),

--- a/src/contexts/CoreContext/mappers/UserMapper.ts
+++ b/src/contexts/CoreContext/mappers/UserMapper.ts
@@ -1,4 +1,4 @@
-import { User } from "../domain/aggregates/User";
+import { User, UserProps } from "../domain/aggregates/User";
 import { User as PrismaUser, UserRole } from "@/generated/prisma";
 import { ICreateUserDto } from "../domain/interfaces/dtos/ICreateUserDto";
 import { UserEmail } from "../domain/valueObjects/UserEmail";
@@ -16,6 +16,7 @@ export default class UserMapper {
         roles: ["CLIENT"],
         createdAt: new Date(),
         profilePicture: dto.profilePicture,
+        about: dto.about,
       },
       new UniqueEntityID(dto.id)
     );
@@ -30,6 +31,7 @@ export default class UserMapper {
       profilePicture: user.profilePicture ?? null,
       roles: roles2,
       createdAt: user.createdAt,
+      about: user.about,
     };
   }
 
@@ -42,6 +44,7 @@ export default class UserMapper {
           roles: userDao.roles,
           createdAt: userDao.createdAt,
           profilePicture: userDao.profilePicture ?? undefined,
+          about: userDao.about,
           freelancerId: userDao.freelancerProfile
             ? new UniqueEntityID(userDao.freelancerProfile.id)
             : undefined,
@@ -67,6 +70,35 @@ export default class UserMapper {
       freelancerProfile: user.props.freelancerId?.toString(),
       clientProfile: user.props.clientId?.toString(),
       profilePicture: user.profilePicture ?? undefined,
+      about: user.about,
+    };
+  }
+
+  static partialDtoToUserProps(
+    dto: Partial<ICreateUserDto>
+  ): Partial<UserProps> {
+    const result: Partial<UserProps> = {};
+
+    if (dto.userName !== undefined) {
+      result.userName = UserName.create(dto.userName);
+    }
+    if (dto.profilePicture !== undefined) {
+      result.profilePicture = dto.profilePicture;
+    }
+    if (dto.about !== undefined) {
+      result.about = dto.about;
+    }
+
+    return result;
+  }
+
+  static partialDtoToUpdateProps(
+    dto: Partial<ICreateUserDto>
+  ): Partial<UserProps> {
+    return {
+      userName: dto.userName ? UserName.create(dto.userName) : undefined,
+      profilePicture: dto.profilePicture,
+      about: dto.about,
     };
   }
 }

--- a/src/contexts/CoreContext/presentation/http/controllers/AuthController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/AuthController.ts
@@ -36,6 +36,7 @@ export class AuthController implements IAuthController {
         userName: tokenData.name ?? "Unknown User",
         userEmail: tokenData.email ?? "Unknown Email",
         profilePicture: "",
+        about: "",
       });
 
       await this.authService.updateUserRoles(user, role);
@@ -69,6 +70,7 @@ export class AuthController implements IAuthController {
         userName: tokenData.name ?? "Unknown User",
         userEmail: tokenData.email ?? "Unknown Email",
         profilePicture: "",
+        about: "",
       };
 
       console.log("Syncing user controller start", dto);

--- a/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
+++ b/src/contexts/CoreContext/presentation/http/controllers/UserController.ts
@@ -56,16 +56,25 @@ export class UserController implements IUserController {
       console.log(error);
     }
   };
+
   updateUser = async (req: Request, res: Response): Promise<void> => {
-    const userId = req.user?.id;
-    const userData: ICreateUserDto = req.body;
+    const userId = req.user?.id ?? req.params.id;
     if (!userId) {
       throw new ApiError(StatusCodes.UNAUTHORIZED, "User not authenticated");
     }
+
     try {
-      userData.userEmail = "a@example.com";
-      const user = UserMapper.createUserDtoTodomain(userData);
-      const updatedUser = await this.userService.update(userId, user);
+      const partialDto = req.body as Partial<ICreateUserDto>;
+
+      const userProps = UserMapper.partialDtoToUpdateProps(partialDto);
+
+      const updatedUser = await this.userService.updateUserProfile(
+        userId,
+        userProps
+      );
+      if (!updatedUser) {
+        throw new ApiError(StatusCodes.NOT_FOUND, "User not found");
+      }
       const response = new SuccessResponseEntity(
         UserMapper.domainToGetUserDto(updatedUser),
         StatusCodes.OK,

--- a/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
+++ b/src/contexts/CoreContext/presentation/http/routes/UserRoutes.ts
@@ -55,37 +55,38 @@ router.get("/:id", controller.get);
 router.post("/", controller.post);
 
 /**
- *
  * @openapi
- * /users:
- *  patch:
- *     summary: Updates the user data
+ * /users/{id}:
+ *   patch:
+ *     summary: Updates user data (userName, profilePicture or about)
  *     tags:
  *       - User
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the user to update
  *     requestBody:
  *       required: true
  *       content:
  *         application/x-www-form-urlencoded:
  *           schema:
- *             $ref: '#/components/schemas/User'
+ *             $ref: '#/components/schemas/UpdateUser'
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/User'
+ *             $ref: '#/components/schemas/UpdateUser'
  *     responses:
  *       200:
  *         description: User updated successfully
+ *       404:
+ *         description: User not found
  *       500:
  *         description: Internal server error
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
- *                   example: "An error occurred while updating the user"
  */
-router.patch("/", verifyToken(), controller.updateUser);
+router.patch("/:id", controller.updateUser);
+// router.patch("/users/me", verifyToken(), controller.updateUserOwnProfile);
 
 /**
  * @openapi
@@ -133,4 +134,27 @@ export default router;
  *       required:
  *         - userName
  *         - userEmail
+ */
+
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     UpdateUser:
+ *       type: object
+ *       properties:
+ *         userName:
+ *           type: string
+ *           description: New username of the user
+ *           example: "George Orwell"
+ *         profilePicture:
+ *           type: string
+ *           format: uri
+ *           description: URL of the profile picture
+ *           example: "https://example.com/avatar.jpg"
+ *         about:
+ *           type: string
+ *           description: Short bio or about section
+ *           example: "Passionate literature teacher inspiring young minds."
+ *       # No 'required' → todos los campos son opcionales
  */

--- a/tests/contexts/coreContext/Freelancer.spec.ts
+++ b/tests/contexts/coreContext/Freelancer.spec.ts
@@ -1,7 +1,6 @@
 import { Education } from "@/contexts/CoreContext/domain/entities/Education";
 import { Experience } from "@/contexts/CoreContext/domain/entities/Experience";
 import { Freelancer } from "@/contexts/CoreContext/domain/aggregates/Freelancer";
-import { About } from "@/contexts/CoreContext/domain/valueObjects/About";
 import { Certification } from "@/contexts/CoreContext/domain/entities/Certification";
 import { Language } from "@/contexts/CoreContext/domain/entities/Language";
 import { Skill } from "@/contexts/CoreContext/domain/entities/Skill";
@@ -16,10 +15,6 @@ import { Certifications } from "@/contexts/CoreContext/domain/OneToMany/Certific
 describe("Freelancer Entity", () => {
   it("should create a valid Freelancer with all properties", () => {
     const userId = UserId.create(new UniqueEntityID());
-
-    const about = About.create(
-      "Passionate full-stack developer with 5+ years of experience."
-    );
 
     const skills = Skills.create([
       new Skill(
@@ -71,7 +66,6 @@ describe("Freelancer Entity", () => {
 
     const freelancer = Freelancer.create({
       userId,
-      about,
       skills: skills,
       languages: languages,
       education: educations,
@@ -81,9 +75,6 @@ describe("Freelancer Entity", () => {
 
     expect(freelancer).toBeDefined();
     expect(freelancer.userId.equals(userId)).toBe(true);
-    expect(freelancer.about.value).toBe(
-      "Passionate full-stack developer with 5+ years of experience."
-    );
     expect(freelancer.skills.getItems().length).toBe(2);
     expect(freelancer.languages.getItems().length).toBe(2);
     expect(freelancer.education.getItems().length).toBe(1);

--- a/tests/contexts/coreContext/User.spec.ts
+++ b/tests/contexts/coreContext/User.spec.ts
@@ -3,7 +3,6 @@ import { Client } from "@/contexts/CoreContext/domain/aggregates/Client";
 import { Education } from "@/contexts/CoreContext/domain/entities/Education";
 import { Experience } from "@/contexts/CoreContext/domain/entities/Experience";
 import { Freelancer } from "@/contexts/CoreContext/domain/aggregates/Freelancer";
-import { About } from "@/contexts/CoreContext/domain/valueObjects/About";
 import { Certification } from "@/contexts/CoreContext/domain/entities/Certification";
 import { Language } from "@/contexts/CoreContext/domain/entities/Language";
 import { Skill } from "@/contexts/CoreContext/domain/entities/Skill";
@@ -24,10 +23,6 @@ describe("User Aggregate", () => {
 
   //Client
   const client = Client.create({ userId });
-
-  const about = About.create(
-    "Passionate full-stack developer with 5+ years of experience."
-  );
 
   const skillService = Skills.create([
     new Skill(
@@ -80,7 +75,6 @@ describe("User Aggregate", () => {
   //Freelancer
   const freelancer = Freelancer.create({
     userId,
-    about,
     skills: skillService,
     languages: languageService,
     education: educationService,
@@ -95,6 +89,7 @@ describe("User Aggregate", () => {
       roles: ["CLIENT"],
       clientId: new UniqueEntityID(),
       createdAt: new Date(),
+      about: "",
     });
 
     expect(user).toBeDefined();
@@ -110,6 +105,7 @@ describe("User Aggregate", () => {
       roles: ["FREELANCER"],
       freelancerId: new UniqueEntityID(),
       createdAt: new Date(),
+      about: "",
     });
 
     expect(user).toBeDefined();
@@ -125,6 +121,7 @@ describe("User Aggregate", () => {
         userEmail,
         roles: ["FREELANCER"],
         createdAt: new Date(),
+        about: "",
       })
     ).toThrow("Freelancer profile is required for role FREELANCER.");
   });
@@ -149,6 +146,7 @@ describe("User Aggregate", () => {
       clientId: new UniqueEntityID(),
       createdAt: new Date(),
       roles: [],
+      about: "",
     });
 
     expect(user.roles).toContain("CLIENT");
@@ -162,6 +160,7 @@ describe("User Aggregate", () => {
       roles: ["CLIENT"],
       clientId: new UniqueEntityID(),
       createdAt: new Date(),
+      about: "",
     });
 
     user.assignFreelancerProfile(new UniqueEntityID());

--- a/tests/contexts/coreContext/application/useCases/AddSkillUseCase.spec.ts
+++ b/tests/contexts/coreContext/application/useCases/AddSkillUseCase.spec.ts
@@ -4,7 +4,6 @@ import { Skill } from "@/contexts/CoreContext/domain/entities/Skill";
 import { Freelancer } from "@/contexts/CoreContext/domain/aggregates/Freelancer";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
 import { UserId } from "@/contexts/CoreContext/domain/valueObjects/UserId";
-import { About } from "@/contexts/CoreContext/domain/valueObjects/About";
 import { Skills } from "@/contexts/CoreContext/domain/OneToMany/Skills";
 import { Languages } from "@/contexts/CoreContext/domain/OneToMany/Languages";
 import { Educations } from "@/contexts/CoreContext/domain/OneToMany/Educations";
@@ -40,7 +39,6 @@ describe("testing AddSkillUseCase component to add skills to freelancer", () => 
     const skills: Skill[] = [];
     const emptyFreelancer: Freelancer = Freelancer.create({
       userId: UserId.create(new UniqueEntityID()),
-      about: About.create(""),
       skills: Skills.create(skills),
       languages: Languages.create([]),
       education: Educations.create([]),
@@ -67,7 +65,6 @@ describe("testing AddSkillUseCase component to add skills to freelancer", () => 
     );
     const emptyFreelancer: Freelancer = Freelancer.create({
       userId: UserId.create(new UniqueEntityID()),
-      about: About.create(""),
       skills: Skills.create(skills),
       languages: Languages.create([]),
       education: Educations.create([]),
@@ -93,7 +90,6 @@ describe("testing AddSkillUseCase component to add skills to freelancer", () => 
     ];
     const emptyFreelancer: Freelancer = Freelancer.create({
       userId: UserId.create(new UniqueEntityID()),
-      about: About.create(""),
       skills: Skills.create(skills),
       languages: Languages.create([]),
       education: Educations.create([]),

--- a/tests/contexts/coreContext/application/useCases/DeleteSkillUseCase.spec.ts
+++ b/tests/contexts/coreContext/application/useCases/DeleteSkillUseCase.spec.ts
@@ -4,7 +4,6 @@ import DeleteSkillUseCase from "@/contexts/CoreContext/application/useCases/Dele
 import { Freelancer } from "@/contexts/CoreContext/domain/aggregates/Freelancer";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
 import { UserId } from "@/contexts/CoreContext/domain/valueObjects/UserId";
-import { About } from "@/contexts/CoreContext/domain/valueObjects/About";
 import { Skills } from "@/contexts/CoreContext/domain/OneToMany/Skills";
 import { Languages } from "@/contexts/CoreContext/domain/OneToMany/Languages";
 import { Educations } from "@/contexts/CoreContext/domain/OneToMany/Educations";
@@ -35,7 +34,6 @@ describe("testing DeleteSkillUseCase to delete skills from freelancer", () => {
   } as any;
   const empyFreelancer: Freelancer = Freelancer.create({
     userId: UserId.create(new UniqueEntityID()),
-    about: About.create(""),
     skills: Skills.create([]),
     languages: Languages.create([]),
     education: Educations.create([]),

--- a/tests/contexts/coreContext/application/useCases/EditSkillUseCase.spec.ts
+++ b/tests/contexts/coreContext/application/useCases/EditSkillUseCase.spec.ts
@@ -5,7 +5,6 @@ import { ISkillRepository } from "@/contexts/CoreContext/domain/interfaces/repos
 import { Freelancer } from "@/contexts/CoreContext/domain/aggregates/Freelancer";
 import { UserId } from "@/contexts/CoreContext/domain/valueObjects/UserId";
 import { UniqueEntityID } from "@/contexts/Shared/domain/UniqueEntityID";
-import { About } from "@/contexts/CoreContext/domain/valueObjects/About";
 import { Certifications } from "@/contexts/CoreContext/domain/OneToMany/Certifications";
 import { Skills } from "@/contexts/CoreContext/domain/OneToMany/Skills";
 import { Languages } from "@/contexts/CoreContext/domain/OneToMany/Languages";
@@ -35,7 +34,6 @@ describe("testing EditSkillUseCase to change the params of a skill", () => {
   } as any;
   const empyFreelancer: Freelancer = Freelancer.create({
     userId: UserId.create(new UniqueEntityID()),
-    about: About.create(""),
     skills: Skills.create([]),
     languages: Languages.create([]),
     education: Educations.create([]),

--- a/tests/contexts/coreContext/presentation/http/controllers/AuthController.syncUser.spec.ts
+++ b/tests/contexts/coreContext/presentation/http/controllers/AuthController.syncUser.spec.ts
@@ -71,6 +71,7 @@ describe("AuthController.syncUser", () => {
       userName: "Test User",
       userEmail: "test@example.com",
       profilePicture: "",
+      about: "",
     });
 
     expect(userService.syncUser).toHaveBeenCalledWith(

--- a/tests/contexts/coreContext/presentation/http/controllers/AuthController.updateUserRoles.spec.ts
+++ b/tests/contexts/coreContext/presentation/http/controllers/AuthController.updateUserRoles.spec.ts
@@ -35,7 +35,7 @@ describe("AuthController - updateUserRoles", () => {
 
   it("should update user roles and send success response", async () => {
     req = {
-      user: { id: "1", name: "Test", email: "test@example.com" },
+      user: { id: "1", name: "Test", email: "test@example.com", about: "" },
       body: { role: "admin" },
     } as Partial<Request> as Request;
     const mockUser = { id: "1" };
@@ -48,6 +48,7 @@ describe("AuthController - updateUserRoles", () => {
       userName: "Test",
       userEmail: "test@example.com",
       profilePicture: "",
+      about: "",
     });
     expect(mockAuthService.updateUserRoles).toHaveBeenCalledWith(
       mockUser,
@@ -78,7 +79,7 @@ describe("AuthController - updateUserRoles", () => {
 
   it("should throw BAD_REQUEST if role is missing", async () => {
     req = {
-      user: { id: "1", name: "Test", email: "test@example.com" },
+      user: { id: "1", name: "Test", email: "test@example.com", about: "" },
       body: {},
     } as Partial<Request> as Request;
 
@@ -95,7 +96,7 @@ describe("AuthController - updateUserRoles", () => {
 
   it("should handle errors from authService.updateUserRoles", async () => {
     req = {
-      user: { id: "1", name: "Test", email: "test@example.com" },
+      user: { id: "1", name: "Test", email: "test@example.com", about: "" },
       body: { role: "admin" },
     } as Partial<Request> as Request;
     const mockUser = { id: "1" };

--- a/tests/contexts/coreContext/useCases/SyncUserUseCase.spec.ts
+++ b/tests/contexts/coreContext/useCases/SyncUserUseCase.spec.ts
@@ -12,6 +12,7 @@ describe("SyncUserUseCase", () => {
     create: jest.Mock<Promise<User>, [User]>;
     addFreelancerProfile: jest.Mock;
     getUserProfileById: jest.Mock;
+    updateUserProfile: jest.Mock;
     getAll: jest.Mock;
     delete: jest.Mock;
     update: jest.Mock;
@@ -30,6 +31,7 @@ describe("SyncUserUseCase", () => {
 
     repository = {
       getById: jest.fn(),
+      updateUserProfile: jest.fn(),
       create: jest.fn(),
       addFreelancerProfile: jest.fn(),
       getUserProfileById: jest.fn(),


### PR DESCRIPTION
## Description

This PR has the migration of the `About` field from the Freelancer to the User aggregate. Change of tests, controllers, repository and schema.

## Main Changes
- Change the PATCH endpoint to receive the id of the user.
- Implemented the about in the User aggregate.
- The fields about, profilePicture and userName can be updated by sending the optional fields.
- Tests updated according to changes made

## Reviewers
<img width="1116" height="582" alt="image" src="https://github.com/user-attachments/assets/fbf14999-8ca8-4e55-8ae6-ff99b5512aea" />
<img width="1052" height="535" alt="image" src="https://github.com/user-attachments/assets/bce535e5-8b19-4cac-8319-4085a2b86113" />

@LucasMezzaJalaUniversity
@JoseCaJala
@cclaurevju
@ArielMonroy392
@MauricioLSalles
@ElamCanoJala
@AndreCarpio
@DanielRios491
@eduSpinouza
